### PR TITLE
Gave code block comment a break in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ let section = TableSection(key: "header-unique-key", rows: [])
 Each section contains a series of rows where each row value must conform to the `CellConfigType` protocol.
 
 ```swift
-/// The simplest possible version of a cell that displays a label. Useful to get started, but in most cases a more robust state should be used allowing more customization.
+/// The simplest possible version of a cell that displays a label.
+/// Useful to get started, but in most cases a more robust state should be used allowing more customization.
 typealias LabelCell = HostCell<UILabel, String, LayoutMarginsTableItemLayout>
 
 let cells: [CellConfigType] = [


### PR DESCRIPTION
Why?
 
![nov-20-2017 14-45-55](https://user-images.githubusercontent.com/11095731/33089836-e7b16b24-cebf-11e7-9307-667816f0d2e8.gif)

View the [rich changes ](https://github.com/BenEmdon/FunctionalTableData/blob/ba27437f11898f58f08574be4cecb75743d33cd3/README.md)