### PR TITLE
fix bug where canSelectAction wasn't being passed through the initializer chain

### DIFF
--- a/FunctionalTableData/CellActions.swift
+++ b/FunctionalTableData/CellActions.swift
@@ -70,6 +70,6 @@ public struct CellActions {
 			previewingContext.sourceRect = previewingContext.sourceView.convert(cell.bounds, from: cell)
 			return previewingViewControllerAction()
 		}
-		self.init(selectionAction: selectionAction, rowActions: rowActions, canPerformAction: canPerformAction, canBeMoved: canBeMoved, visibilityAction: visibilityAction, previewingViewControllerAction: wrappedPreviewingViewControllerAction)
+		self.init(canSelectAction: canSelectAction, selectionAction: selectionAction, rowActions: rowActions, canPerformAction: canPerformAction, canBeMoved: canBeMoved, visibilityAction: visibilityAction, previewingViewControllerAction: wrappedPreviewingViewControllerAction)
 	}
 }


### PR DESCRIPTION
## Description of change:
`CellActions` has two initializers. The second one wasn't propagating the `canSelectAction` argument to the first one.