### PR TITLE
Cancel outstanding operations

### DIFF
--- a/FunctionalTableData/TableView/FunctionalTableData.swift
+++ b/FunctionalTableData/TableView/FunctionalTableData.swift
@@ -283,6 +283,10 @@ public class FunctionalTableData: NSObject {
 			
 			strongSelf.doRenderAndDiff(newSections, animated: animated, animations: animations, completion: completion)
 		}
+		renderAndDiffQueue.operations.forEach { (operation) in
+			guard operation.isExecuting == false else { return }
+			operation.cancel()
+		}
 		renderAndDiffQueue.addOperation(blockOperation)
 	}
 	

--- a/FunctionalTableData/TableView/FunctionalTableData.swift
+++ b/FunctionalTableData/TableView/FunctionalTableData.swift
@@ -283,10 +283,8 @@ public class FunctionalTableData: NSObject {
 			
 			strongSelf.doRenderAndDiff(newSections, animated: animated, animations: animations, completion: completion)
 		}
-		renderAndDiffQueue.operations.forEach { (operation) in
-			guard operation.isExecuting == false else { return }
-			operation.cancel()
-		}
+		//cancel waiting operations since only the last state needs to be rendered
+		renderAndDiffQueue.operations.lazy.filter { !$0.isExecuting }.forEach { $0.cancel() }
 		renderAndDiffQueue.addOperation(blockOperation)
 	}
 	


### PR DESCRIPTION
In some situations operations can pile up in the renderAndDiff queue. It's not necessary to run all of them because the last one added should provide the correct state to display. This PR cancels any outstanding operations that are not already executing before adding the new operation to the queue.