### PR TITLE
Added void to catchAndRethrowException block definition 

### DIFF
--- a/FunctionalTableData/FunctionalTableData.h
+++ b/FunctionalTableData/FunctionalTableData.h
@@ -18,7 +18,7 @@ FOUNDATION_EXPORT const unsigned char FunctionalTableDataVersionString[];
 NS_ASSUME_NONNULL_BEGIN
 
 __attribute__((visibility("hidden")))
-static inline void catchAndRethrowException(__attribute__((noescape)) void (^ __nonnull inBlock)(), __attribute__((noescape)) void (^ __nonnull rethrow)(NSException *)) {
+static inline void catchAndRethrowException(__attribute__((noescape)) void (^ __nonnull inBlock)(void), __attribute__((noescape)) void (^ __nonnull rethrow)(NSException *)) {
 	@try {
 		inBlock();
 	} @catch (NSException *exception) {


### PR DESCRIPTION
Added void to Block definition because we don’t expect params to be passed. This is to fix an issue on an internal project where tests were not building.