### PR TITLE
Remove unused updateRow function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # CHANGELOG
 
 The change log for `FunctionalTableData`.
+1.1.3
+-----
+- Remove the unused, non-public function `updateRow` from `FunctionalTableData` and `FunctionalCollectionData`
+- Add `void` to block definition where no params are expected
+
 1.1.2
 -----
 - Fixes an issue that caused laggy renders. Operations were queued by many quick calls to `renderAndDiff`

--- a/FunctionalTableData/CollectionView/FunctionalCollectionData.swift
+++ b/FunctionalTableData/CollectionView/FunctionalCollectionData.swift
@@ -90,19 +90,6 @@ public class FunctionalCollectionData: NSObject {
 		collectionView?.delegate = nil
 	}
 	
-	func updateRow(keyPath: KeyPath, newRow: CellConfigType, completionAction: (() -> Void)? = nil) {
-		guard let collectionView = collectionView else { return }
-		if let indexPath = indexPathFromKeyPath(keyPath), let cell = collectionView.cellForItem(at: indexPath) {
-			newRow.update(cell: cell, in: collectionView)
-		}
-		
-		if let sectionIndex = sections.index(where: { $0.key == keyPath.sectionKey }), let rowIndex = sections[sectionIndex].rows.index(where: { $0.key == keyPath.rowKey }) {
-			sections[sectionIndex].rows[rowIndex] = newRow
-		}
-		
-		completionAction?()
-	}
-	
 	/// Returns the cell identified by a key path.
 	///
 	/// - Parameter keyPath: A key path identifying the cell to look up.

--- a/FunctionalTableData/TableView/FunctionalTableData.swift
+++ b/FunctionalTableData/TableView/FunctionalTableData.swift
@@ -137,19 +137,6 @@ public class FunctionalTableData: NSObject {
 		tableView?.delegate = nil
 	}
 	
-	func updateRow(keyPath: KeyPath, newRow: CellConfigType, completionAction: (() -> Void)? = nil) {
-		guard let tableView = tableView else { return }
-		if let indexPath = indexPathFromKeyPath(keyPath), let cell = tableView.cellForRow(at: indexPath) {
-			newRow.update(cell: cell, in: tableView)
-		}
-		
-		if let sectionIndex = sections.index(where: { $0.key == keyPath.sectionKey }), let rowIndex = sections[sectionIndex].rows.index(where: { $0.key == keyPath.rowKey }) {
-			sections[sectionIndex].rows[rowIndex] = newRow
-		}
-		
-		completionAction?()
-	}
-	
 	/// Returns the cell identified by a key path.
 	///
 	/// - Parameter keyPath: A key path identifying the cell to look up.

--- a/FunctionalTableDataTests/FunctionalDataTests.swift
+++ b/FunctionalTableDataTests/FunctionalDataTests.swift
@@ -10,55 +10,6 @@ import XCTest
 @testable import FunctionalTableData
 
 class FunctionalDataTests: XCTestCase {
-	func testUpdateRow() {
-		let tableData = FunctionalTableData()
-		let tableView = UITableView()
-		
-		tableData.tableView = tableView
-		
-		let expectation1 = expectation(description: "render and diff happens")
-		let cellConfigC1 = TestCaseCell(key: "color1", state: TestCaseState(data: "red"), cellUpdater: TestCaseState.updateView)
-		let cellConfigC2 = TestCaseCell(key: "color2", state: TestCaseState(data: "green"), cellUpdater: TestCaseState.updateView)
-		let sectionC1 = TableSection(key: "colors Section", rows: [cellConfigC1, cellConfigC2])
-		
-		let cellConfigS1 = TestCaseCell(key: "size1", state: TestCaseState(data: "medium"), cellUpdater: TestCaseState.updateView)
-		let cellConfigS2 = TestCaseCell(key: "size2", state: TestCaseState(data: "large"), cellUpdater: TestCaseState.updateView)
-		let sectionS1 = TableSection(key: "sizes Section", rows: [cellConfigS1, cellConfigS2])
-		
-		let expectation2 = expectation(description: "size1 Update")
-		let cellConfigS1B = TestCaseCell(key: "size1", state: TestCaseState(data: "small"), cellUpdater: TestCaseState.updateView)
-		
-		let updateKeyPath = FunctionalTableData.KeyPath(sectionKey: "sizes Section", rowKey: "size1")
-		
-		tableData.renderAndDiff([sectionC1, sectionS1], animated: false) { [weak tableData] in
-			expectation1.fulfill()
-			if let tableData = tableData, let tableView = tableData.tableView {
-				XCTAssertEqual(tableView.numberOfSections, 2)
-				XCTAssertEqual(tableView.numberOfRows(inSection: 0), 2)
-				XCTAssertEqual(tableView.numberOfRows(inSection: 1), 2)
-				
-				if let row = tableData.rowForKeyPath(updateKeyPath) {
-					XCTAssertTrue(row.isEqual(cellConfigS1))
-				}
-				
-				tableData.updateRow(keyPath: updateKeyPath, newRow: cellConfigS1B) { [weak tableData] in
-					expectation2.fulfill()
-					if let tableData = tableData, let tableView = tableData.tableView {
-						XCTAssertEqual(tableView.numberOfSections, 2)
-						XCTAssertEqual(tableView.numberOfRows(inSection: 0), 2)
-						XCTAssertEqual(tableView.numberOfRows(inSection: 1), 2)
-						
-						if let row = tableData.rowForKeyPath(updateKeyPath) {
-							XCTAssertTrue(row.isEqual(cellConfigS1B))
-						}
-					}
-				}
-			}
-		}
-		
-		waitForExpectations(timeout: 1, handler: nil)
-	}
-	
 	func testKeyPathFromRowKey() {
 		let tableData = FunctionalTableData()
 		let tableView = UITableView()


### PR DESCRIPTION
The function was never made public, so was unavailable outside of the module, and hasn't been touched since the project released.

After discussion, this function goes against the mantra of the FunctionalTable/CollectionData model as a single row isn't meant to be touched. As @g-Off also pointed out, there's no guarantees the `CellConfigType` matches what's in the row being changed, and there's no checks to see if it might be interrupting an active `renderAndDiff`