### PR TITLE
Host cell equality

### DIFF
--- a/FunctionalTableData.xcodeproj/project.pbxproj
+++ b/FunctionalTableData.xcodeproj/project.pbxproj
@@ -497,7 +497,6 @@
 				DEVELOPMENT_TEAM = UD42KN75C7;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = FunctionalTableDataDemo/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.jadedpixel.FunctionalTableDataDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -519,7 +518,6 @@
 				DEVELOPMENT_TEAM = UD42KN75C7;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = FunctionalTableDataDemo/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.jadedpixel.FunctionalTableDataDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/FunctionalTableDataTests/TableSectionStyleTests.swift
+++ b/FunctionalTableDataTests/TableSectionStyleTests.swift
@@ -57,7 +57,7 @@ class TableSectionStyleTests: XCTestCase {
 		let style = SectionStyle(separators: .default)
 		let section = TableSection(key: "section", rows: rows, style: style)
 		
-		let styles = (0..<3).flatMap { section.mergedStyle(for: $0) }
+		let styles = (0..<3).compactMap { section.mergedStyle(for: $0) }
 		XCTAssertEqual(styles.count, rows.count)
 		XCTAssertEqual(styles[0], CellStyle(topSeparator: .full, bottomSeparator: .inset))
 		XCTAssertEqual(styles[1], CellStyle(bottomSeparator: .inset))


### PR DESCRIPTION
## What

This adds `key` and `style` to the equality definition of `CellConfigType`. While most style changes are accompanied by state changes, it's not always the case for indexed items that change positions. Adding style makes it more likely we update cells when they change their merged style. This also allows us to compare `CellConfigType`s more accurately outside of FunctionalTableData.


### Bonus ✨

- Allow demo app to be used with iOS 9.0+
- 🔥 1 warning