### PR TITLE
Improve canSelectAction, selectionAction

### DIFF
--- a/FunctionalTableData/CellActions.swift
+++ b/FunctionalTableData/CellActions.swift
@@ -18,7 +18,7 @@ public struct CellActions {
 	
 	public typealias CanSelectCallback = (Bool) -> Void
 	public typealias CanSelectAction = (_ canSelect: @escaping CanSelectCallback) -> Void
-	public typealias SelectionAction = (_ sender: UIView) -> SelectionState
+	public typealias SelectionAction = (_ sender: UIView, _ isSelecting: Bool) -> SelectionState
 	public typealias CanPerformAction = (_ selector: Selector) -> Bool
 	public typealias VisibilityAction = (_ cell: UIView, _ visible: Bool) -> Void
 	/// Closure type that is executed when the user 3D-touches on a cell

--- a/FunctionalTableData/CellActions.swift
+++ b/FunctionalTableData/CellActions.swift
@@ -18,7 +18,8 @@ public struct CellActions {
 	
 	public typealias CanSelectCallback = (Bool) -> Void
 	public typealias CanSelectAction = (_ canSelect: @escaping CanSelectCallback) -> Void
-	public typealias SelectionAction = (_ sender: UIView, _ isSelecting: Bool) -> SelectionState
+	public typealias SelectionAction = (_ sender: UIView) -> SelectionState
+	public typealias DeselectionAction = (_ sender: UIView) -> SelectionState
 	public typealias CanPerformAction = (_ selector: Selector) -> Bool
 	public typealias VisibilityAction = (_ cell: UIView, _ visible: Bool) -> Void
 	/// Closure type that is executed when the user 3D-touches on a cell
@@ -32,6 +33,8 @@ public struct CellActions {
 	public let canSelectAction: CanSelectAction?
 	/// The action to perform when the cell is selected
 	public let selectionAction: SelectionAction?
+	/// The action to perform when the cell is deselected
+	public let deselectionAction: SelectionAction?
 	/// All the available row actions this cell can perform. See [UITableViewRowAction](https://developer.apple.com/documentation/uikit/uitableviewrowaction) for more info.
 	public let rowActions: [UITableViewRowAction]?
 	/// Indicates if the cell can perform a given action.
@@ -45,6 +48,7 @@ public struct CellActions {
 	
 	public init(canSelectAction: CanSelectAction? = nil,
 				selectionAction: SelectionAction? = nil,
+				deselectionAction: DeselectionAction? = nil,
 				rowActions: [UITableViewRowAction]? = nil,
 				canPerformAction: CanPerformAction? = nil,
 				canBeMoved: Bool = false,
@@ -52,6 +56,7 @@ public struct CellActions {
 				previewingViewControllerAction: PreviewingViewControllerAction? = nil) {
 		self.canSelectAction = canSelectAction
 		self.selectionAction = selectionAction
+		self.deselectionAction = deselectionAction
 		self.rowActions = rowActions
 		self.canPerformAction = canPerformAction
 		self.canBeMoved = canBeMoved
@@ -61,6 +66,7 @@ public struct CellActions {
 	
 	public init(canSelectAction: CanSelectAction? = nil,
 				selectionAction: SelectionAction? = nil,
+				deselectionAction: DeselectionAction? = nil,
 				rowActions: [UITableViewRowAction]? = nil,
 				canPerformAction: CanPerformAction? = nil,
 				canBeMoved: Bool = false,
@@ -70,6 +76,6 @@ public struct CellActions {
 			previewingContext.sourceRect = previewingContext.sourceView.convert(cell.bounds, from: cell)
 			return previewingViewControllerAction()
 		}
-		self.init(canSelectAction: canSelectAction, selectionAction: selectionAction, rowActions: rowActions, canPerformAction: canPerformAction, canBeMoved: canBeMoved, visibilityAction: visibilityAction, previewingViewControllerAction: wrappedPreviewingViewControllerAction)
+		self.init(canSelectAction: canSelectAction, selectionAction: selectionAction, deselectionAction: deselectionAction, rowActions: rowActions, canPerformAction: canPerformAction, canBeMoved: canBeMoved, visibilityAction: visibilityAction, previewingViewControllerAction: wrappedPreviewingViewControllerAction)
 	}
 }

--- a/FunctionalTableData/CollectionView/FunctionalCollectionData.swift
+++ b/FunctionalTableData/CollectionView/FunctionalCollectionData.swift
@@ -467,10 +467,10 @@ extension FunctionalCollectionData: UICollectionViewDataSource {
 
 extension FunctionalCollectionData: UICollectionViewDelegate {
 	public func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
-		guard let indexPathsForSelectedItems = collectionView.indexPathsForSelectedItems else { return true }
+		guard let indexPathsForSelectedItems = collectionView.indexPathsForSelectedItems, !collectionView.allowsMultipleSelection else { return true }
 		return indexPathsForSelectedItems.contains(indexPath) == false
 	}
-	
+
 	public func collectionView(_ collectionView: UICollectionView, shouldHighlightItemAt indexPath: IndexPath) -> Bool {
 		return sections[indexPath]?.actions.selectionAction != nil
 	}
@@ -479,10 +479,22 @@ extension FunctionalCollectionData: UICollectionViewDelegate {
 		guard let cell = collectionView.cellForItem(at: indexPath) else { return }
 		let cellConfig = sections[indexPath]
 		
-		let selectionState = cellConfig?.actions.selectionAction?(cell) ?? .deselected
+		let selectionState = cellConfig?.actions.selectionAction?(cell, true) ?? .deselected
 		if selectionState == .deselected {
 			DispatchQueue.main.async {
 				collectionView.deselectItem(at: indexPath, animated: true)
+			}
+		}
+	}
+
+	public func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
+		guard let cell = collectionView.cellForItem(at: indexPath) else { return }
+		let cellConfig = sections[indexPath]
+		
+		let selectionState = cellConfig?.actions.selectionAction?(cell, false) ?? .deselected
+		if selectionState == .selected {
+			DispatchQueue.main.async {
+				collectionView.selectItem(at: indexPath, animated: true, scrollPosition: [])
 			}
 		}
 	}

--- a/FunctionalTableData/CollectionView/FunctionalCollectionData.swift
+++ b/FunctionalTableData/CollectionView/FunctionalCollectionData.swift
@@ -479,7 +479,7 @@ extension FunctionalCollectionData: UICollectionViewDelegate {
 		guard let cell = collectionView.cellForItem(at: indexPath) else { return }
 		let cellConfig = sections[indexPath]
 		
-		let selectionState = cellConfig?.actions.selectionAction?(cell, true) ?? .deselected
+		let selectionState = cellConfig?.actions.selectionAction?(cell) ?? .deselected
 		if selectionState == .deselected {
 			DispatchQueue.main.async {
 				collectionView.deselectItem(at: indexPath, animated: true)
@@ -491,7 +491,7 @@ extension FunctionalCollectionData: UICollectionViewDelegate {
 		guard let cell = collectionView.cellForItem(at: indexPath) else { return }
 		let cellConfig = sections[indexPath]
 		
-		let selectionState = cellConfig?.actions.selectionAction?(cell, false) ?? .deselected
+		let selectionState = cellConfig?.actions.deselectionAction?(cell) ?? .deselected
 		if selectionState == .selected {
 			DispatchQueue.main.async {
 				collectionView.selectItem(at: indexPath, animated: true, scrollPosition: [])

--- a/FunctionalTableData/TableView/FunctionalTableData.swift
+++ b/FunctionalTableData/TableView/FunctionalTableData.swift
@@ -617,9 +617,9 @@ extension FunctionalTableData: UITableViewDelegate {
 				if selected {
 					selectedCell.setHighlighted(false, animated: false)
 					
-					if selectionAction(selectedCell, true) == .selected {
+					if selectionAction(selectedCell) == .selected {
 						tableView.selectRow(at: indexPath, animated: false, scrollPosition: .none)
-					} else if selectionAction(selectedCell, false) == .deselected {
+					} else {
 						tableView.deselectRow(at: indexPath, animated: false)
 					}
 
@@ -645,7 +645,7 @@ extension FunctionalTableData: UITableViewDelegate {
 		guard let cell = tableView.cellForRow(at: indexPath) else { return }
 		let cellConfig = sections[indexPath]
 
-		let selectionState = cellConfig?.actions.selectionAction?(cell, true) ?? .deselected
+		let selectionState = cellConfig?.actions.selectionAction?(cell) ?? .deselected
 		if selectionState == .deselected {
 			DispatchQueue.main.async {
 				tableView.deselectRow(at: indexPath, animated: true)
@@ -657,7 +657,7 @@ extension FunctionalTableData: UITableViewDelegate {
 		guard let cell = tableView.cellForRow(at: indexPath) else { return }
 		let cellConfig = sections[indexPath]
 
-		let selectionState = cellConfig?.actions.selectionAction?(cell, false) ?? .deselected
+		let selectionState = cellConfig?.actions.deselectionAction?(cell) ?? .deselected
 		if selectionState == .selected {
 			DispatchQueue.main.async {
 				tableView.selectRow(at: indexPath, animated: true, scrollPosition: .none)

--- a/FunctionalTableData/TableView/FunctionalTableData.swift
+++ b/FunctionalTableData/TableView/FunctionalTableData.swift
@@ -218,7 +218,7 @@ public class FunctionalTableData: NSObject {
 			completion?()
 		}
 	}
-		
+
 	/// Populates the table with the specified sections, and asynchronously updates the table view to reflect the cells and sections that have changed.
 	///
 	/// - Parameters:
@@ -616,12 +616,14 @@ extension FunctionalTableData: UITableViewDelegate {
 				}
 				if selected {
 					selectedCell.setHighlighted(false, animated: false)
-					tableView.selectRow(at: indexPath, animated: false, scrollPosition: .none)
-					if selectionAction(selectedCell) == .deselected {
+					
+					if selectionAction(selectedCell, true) == .selected {
+						tableView.selectRow(at: indexPath, animated: false, scrollPosition: .none)
+					} else if selectionAction(selectedCell, false) == .deselected {
 						tableView.deselectRow(at: indexPath, animated: false)
 					}
-					
-					if let currentSelection = currentSelection {
+
+					if !tableView.allowsMultipleSelection, let currentSelection = currentSelection {
 						tableView.cellForRow(at: currentSelection)?.setHighlighted(false, animated: false)
 						tableView.deselectRow(at: currentSelection, animated: false)
 					}
@@ -643,10 +645,22 @@ extension FunctionalTableData: UITableViewDelegate {
 		guard let cell = tableView.cellForRow(at: indexPath) else { return }
 		let cellConfig = sections[indexPath]
 
-		let selectionState = cellConfig?.actions.selectionAction?(cell) ?? .deselected
+		let selectionState = cellConfig?.actions.selectionAction?(cell, true) ?? .deselected
 		if selectionState == .deselected {
 			DispatchQueue.main.async {
 				tableView.deselectRow(at: indexPath, animated: true)
+			}
+		}
+	}
+
+	public func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {
+		guard let cell = tableView.cellForRow(at: indexPath) else { return }
+		let cellConfig = sections[indexPath]
+
+		let selectionState = cellConfig?.actions.selectionAction?(cell, false) ?? .deselected
+		if selectionState == .selected {
+			DispatchQueue.main.async {
+				tableView.selectRow(at: indexPath, animated: true, scrollPosition: .none)
 			}
 		}
 	}

--- a/FunctionalTableDataDemo/CollectionExampleController.swift
+++ b/FunctionalTableDataDemo/CollectionExampleController.swift
@@ -22,6 +22,7 @@ class CollectionExampleController: UICollectionViewController {
 		
 		collectionView?.backgroundColor = .white
 		functionalData.collectionView = collectionView
+		collectionView?.allowsMultipleSelection = false
 		title = "Collection View"
 		navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .add, target: self, action: #selector(didSelectAdd))
 	}
@@ -35,6 +36,14 @@ class CollectionExampleController: UICollectionViewController {
 			return LabelCell(
 				key: "id-\(index)",
 				style: CellStyle(backgroundColor: .lightGray),
+				actions: CellActions(
+					canSelectAction: { callback in
+						callback(true)
+				},
+					selectionAction: { (view, selected) -> CellActions.SelectionState in
+						print("\(item) is \(selected ? "Selected" : "Deselected")")
+						return selected ? .selected : .deselected
+				}),
 				state: LabelState(text: item),
 				cellUpdater: LabelState.updateView)
 		}

--- a/FunctionalTableDataDemo/CollectionExampleController.swift
+++ b/FunctionalTableDataDemo/CollectionExampleController.swift
@@ -22,7 +22,6 @@ class CollectionExampleController: UICollectionViewController {
 		
 		collectionView?.backgroundColor = .white
 		functionalData.collectionView = collectionView
-		collectionView?.allowsMultipleSelection = false
 		title = "Collection View"
 		navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .add, target: self, action: #selector(didSelectAdd))
 	}
@@ -37,12 +36,13 @@ class CollectionExampleController: UICollectionViewController {
 				key: "id-\(index)",
 				style: CellStyle(backgroundColor: .lightGray),
 				actions: CellActions(
-					canSelectAction: { callback in
-						callback(true)
+					selectionAction: { (view) -> CellActions.SelectionState in
+						print("\(item) is being selected")
+						return .selected
 				},
-					selectionAction: { (view, selected) -> CellActions.SelectionState in
-						print("\(item) is \(selected ? "Selected" : "Deselected")")
-						return selected ? .selected : .deselected
+					deselectionAction: { (view) -> CellActions.SelectionState in
+						print("\(item) is being deselected")
+						return .deselected
 				}),
 				state: LabelState(text: item),
 				cellUpdater: LabelState.updateView)

--- a/FunctionalTableDataDemo/TableExampleController.swift
+++ b/FunctionalTableDataDemo/TableExampleController.swift
@@ -22,6 +22,7 @@ class TableExampleController: UITableViewController {
 		super.viewDidLoad()
 		
 		functionalData.tableView = tableView
+		tableView.allowsMultipleSelection = false
 		title = "Table View"
 		navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .add, target: self, action: #selector(didSelectAdd))
 	}
@@ -34,6 +35,14 @@ class TableExampleController: UITableViewController {
 		let rows: [CellConfigType] = items.enumerated().map { index, item in
 			return LabelCell(
 				key: "id-\(index)",
+				actions: CellActions(
+					canSelectAction: { callback in
+						callback(true)
+				},
+					selectionAction: { (view, selected) -> CellActions.SelectionState in
+						print("\(item) is \(selected ? "Selected" : "Deselected")")
+						return selected ? .selected : .deselected
+				}),
 				state: LabelState(text: item),
 				cellUpdater: LabelState.updateView)
 		}

--- a/FunctionalTableDataDemo/TableExampleController.swift
+++ b/FunctionalTableDataDemo/TableExampleController.swift
@@ -22,7 +22,6 @@ class TableExampleController: UITableViewController {
 		super.viewDidLoad()
 		
 		functionalData.tableView = tableView
-		tableView.allowsMultipleSelection = false
 		title = "Table View"
 		navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .add, target: self, action: #selector(didSelectAdd))
 	}
@@ -36,12 +35,13 @@ class TableExampleController: UITableViewController {
 			return LabelCell(
 				key: "id-\(index)",
 				actions: CellActions(
-					canSelectAction: { callback in
-						callback(true)
+					selectionAction: { (view) -> CellActions.SelectionState in
+						print("\(item) is being selected")
+						return .selected
 				},
-					selectionAction: { (view, selected) -> CellActions.SelectionState in
-						print("\(item) is \(selected ? "Selected" : "Deselected")")
-						return selected ? .selected : .deselected
+					deselectionAction: { (view) -> CellActions.SelectionState in
+						print("\(item) is being deselected")
+						return .deselected
 				}),
 				state: LabelState(text: item),
 				cellUpdater: LabelState.updateView)


### PR DESCRIPTION
Been using this framework in a project for a bit and so far it's been great, but a few things are missing that I would like to fix. Examples of changes are included in the demo app.

# canSelectAction:
If this closure exists, `allowsMultipleSelection` is broken. `willSelectRowAt` now checks for `allowsMultipleSelection` and doesn't deselect the currently selected row if it's enabled. `CollectionData` is also fixed for `allowsMultipleSelection`, although it does not currently call `canSelectAction` at all. Not sure if that's intended or an oversight?

# selectionAction:
The current behaviour only calls this on `didSelect`. It's useful to know when the user deselects as well, so the closure now sends a boolean indicating whether the user is selecting or deselecting.
