### PR TITLE
tests aren't running on travis, using the script option kicks them off

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: swift
+osx_image: xcode9.3
 xcode_project: FunctionalTableData.xcodeproj
 xcode_schema: FunctionalTableDataTests
 notifications:
   disabled: true
-
-env:
-  - PLATFORM=iOS NAME='iPhone SE'
+script:
+  - xcodebuild test -scheme FunctionalTableData -destination "OS=11.3,name=iPhone SE" -sdk iphonesimulator11.3 | xcpretty -c


### PR DESCRIPTION
Travis' YAML file configuration implies that tests run automatically, they don't. This kicks off the test phase using a script because even if you can get the config right it uses `xctool` by default.

How to validate:
If you look at previous test runs there is no build output and they all "succeed" in about 15s. This PR's CI output shows a build and test output and takes ~1.5mins