### PR TITLE
Apply default CellStyle when no custom style is provided

### DIFF
--- a/FunctionalTableData.xcodeproj/project.pbxproj
+++ b/FunctionalTableData.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		4CA356761F322D7F0081BE90 /* TableSectionStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA356741F322D7F0081BE90 /* TableSectionStyleTests.swift */; };
 		4CCCE8481F8AA7F400C73258 /* TableItemLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CCCE8471F8AA7F400C73258 /* TableItemLayout.swift */; };
 		4CD535031F9E3A010041A3F9 /* CellStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CD535021F9E3A010041A3F9 /* CellStyleTests.swift */; };
+		9FF97DB3212CA23B006FA047 /* TableCellReuseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FF97DB2212CA23B006FA047 /* TableCellReuseTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -120,6 +121,7 @@
 		4CCCE8461F8AA7CD00C73258 /* UITableView+Reusable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+Reusable.swift"; sourceTree = "<group>"; };
 		4CCCE8471F8AA7F400C73258 /* TableItemLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableItemLayout.swift; sourceTree = "<group>"; };
 		4CD535021F9E3A010041A3F9 /* CellStyleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellStyleTests.swift; sourceTree = "<group>"; };
+		9FF97DB2212CA23B006FA047 /* TableCellReuseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableCellReuseTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -200,6 +202,7 @@
 				4CA356731F322D7F0081BE90 /* TableSectionChangeSetTests.swift */,
 				4CA356741F322D7F0081BE90 /* TableSectionStyleTests.swift */,
 				36C9208C20D3EB7500DA4251 /* TableSectionsValidationTests.swift */,
+				9FF97DB2212CA23B006FA047 /* TableCellReuseTests.swift */,
 			);
 			path = FunctionalTableDataTests;
 			sourceTree = "<group>";
@@ -476,6 +479,7 @@
 				4C924F261F98E7A3005D2F02 /* FunctionalDataTests.swift in Sources */,
 				4CD535031F9E3A010041A3F9 /* CellStyleTests.swift in Sources */,
 				36C9208D20D3EB7500DA4251 /* TableSectionsValidationTests.swift in Sources */,
+				9FF97DB3212CA23B006FA047 /* TableCellReuseTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/FunctionalTableData/CollectionView/FunctionalCollectionData.swift
+++ b/FunctionalTableData/CollectionView/FunctionalCollectionData.swift
@@ -322,7 +322,7 @@ public class FunctionalCollectionData: NSObject {
 					update.cellConfig.update(cell: cell, in: collectionView)
 					
 					let section = sections[update.index.section]
-					let style = section.mergedStyle(for: update.index.item) ?? CellStyle()
+					let style = section.mergedStyle(for: update.index.item)
 					style.configure(cell: cell, in: collectionView)
 				}
 			}

--- a/FunctionalTableData/CollectionView/FunctionalCollectionData.swift
+++ b/FunctionalTableData/CollectionView/FunctionalCollectionData.swift
@@ -322,8 +322,8 @@ public class FunctionalCollectionData: NSObject {
 					update.cellConfig.update(cell: cell, in: collectionView)
 					
 					let section = sections[update.index.section]
-					let style = section.mergedStyle(for: update.index.item)
-					style?.configure(cell: cell, in: collectionView)
+					let style = section.mergedStyle(for: update.index.item) ?? CellStyle()
+					style.configure(cell: cell, in: collectionView)
 				}
 			}
 		}
@@ -455,7 +455,8 @@ extension FunctionalCollectionData: UICollectionViewDataSource {
 		let cell = cellConfig.dequeueCell(from: collectionView, at: indexPath)
 		
 		cellConfig.update(cell: cell, in: collectionView)
-		cellConfig.style?.configure(cell: cell, in: collectionView)
+		let style = cellConfig.style ?? CellStyle()
+		style.configure(cell: cell, in: collectionView)
 		
 		return cell
 	}

--- a/FunctionalTableData/TableSection.swift
+++ b/FunctionalTableData/TableSection.swift
@@ -90,28 +90,24 @@ public struct TableSection: Sequence, TableSectionType {
 	///
 	/// - Parameter row: Integer identifying the position of the row in the section.
 	/// - Returns: The `CellStyle` of the cell merged with the style of the section.
-	public func mergedStyle(for row: Int) -> CellStyle? {
-		var rowStyle = rows[row].style
+	public func mergedStyle(for row: Int) -> CellStyle {
+		var rowStyle = rows[row].style ?? CellStyle()
 
-		if rowStyle == nil && style != nil {
-			rowStyle = CellStyle()
-		}
-
-		let top = rowStyle?.topSeparator ?? style?.separators.top
-		let bottom = rowStyle?.bottomSeparator ?? style?.separators.bottom
-		let interitem = rowStyle?.bottomSeparator ?? style?.separators.interitem
+		let top = rowStyle.topSeparator ?? style?.separators.top
+		let bottom = rowStyle.bottomSeparator ?? style?.separators.bottom
+		let interitem = rowStyle.bottomSeparator ?? style?.separators.interitem
 		
 		switch (row, rows.index(after: row)) {
 		case (rows.startIndex, rows.endIndex):
-			rowStyle?.topSeparator = top
-			rowStyle?.bottomSeparator = bottom
+			rowStyle.topSeparator = top
+			rowStyle.bottomSeparator = bottom
 		case (rows.startIndex, _):
-			rowStyle?.topSeparator = top
-			rowStyle?.bottomSeparator = interitem
+			rowStyle.topSeparator = top
+			rowStyle.bottomSeparator = interitem
 		case (_, rows.endIndex):
-			rowStyle?.bottomSeparator = bottom
+			rowStyle.bottomSeparator = bottom
 		case (_, _):
-			rowStyle?.bottomSeparator = interitem
+			rowStyle.bottomSeparator = interitem
 		}
 
 		return rowStyle

--- a/FunctionalTableData/TableView/FunctionalTableData.swift
+++ b/FunctionalTableData/TableView/FunctionalTableData.swift
@@ -389,8 +389,8 @@ public class FunctionalTableData: NSObject {
 					update.cellConfig.update(cell: cell, in: tableView)
 					
 					let section = sections[update.index.section]
-					let style = section.mergedStyle(for: update.index.row)
-					style?.configure(cell: cell, in: tableView)
+					let style = section.mergedStyle(for: update.index.row) ?? CellStyle()
+					style.configure(cell: cell, in: tableView)
 				}
 			}
 		}
@@ -543,7 +543,8 @@ extension FunctionalTableData: UITableViewDataSource {
 		let cell = cellConfig.dequeueCell(from: tableView, at: indexPath)
 		
 		cellConfig.update(cell: cell, in: tableView)
-		sectionData.mergedStyle(for: row)?.configure(cell: cell, in: tableView)
+		let style = sectionData.mergedStyle(for: row) ?? CellStyle()
+		style.configure(cell: cell, in: tableView)
 		
 		return cell
 	}

--- a/FunctionalTableData/TableView/FunctionalTableData.swift
+++ b/FunctionalTableData/TableView/FunctionalTableData.swift
@@ -389,7 +389,7 @@ public class FunctionalTableData: NSObject {
 					update.cellConfig.update(cell: cell, in: tableView)
 					
 					let section = sections[update.index.section]
-					let style = section.mergedStyle(for: update.index.row) ?? CellStyle()
+					let style = section.mergedStyle(for: update.index.row)
 					style.configure(cell: cell, in: tableView)
 				}
 			}
@@ -543,7 +543,7 @@ extension FunctionalTableData: UITableViewDataSource {
 		let cell = cellConfig.dequeueCell(from: tableView, at: indexPath)
 		
 		cellConfig.update(cell: cell, in: tableView)
-		let style = sectionData.mergedStyle(for: row) ?? CellStyle()
+		let style = sectionData.mergedStyle(for: row)
 		style.configure(cell: cell, in: tableView)
 		
 		return cell

--- a/FunctionalTableDataTests/TableCellReuseTests.swift
+++ b/FunctionalTableDataTests/TableCellReuseTests.swift
@@ -1,0 +1,87 @@
+//
+//  TableCellReuseTests.swift
+//  FunctionalTableDataTests
+//
+//  Created by Alun Bestor on 2018-08-21.
+//  Copyright © 2018 Shopify. All rights reserved.
+//
+
+import XCTest
+import Foundation
+@testable import FunctionalTableData
+
+class TableCellReuseTests: XCTestCase {
+	private typealias LabelCell = HostCell<UILabel, String, LayoutMarginsTableItemLayout>
+	
+	private var tableView: UITableView!
+	private var tableModel: FunctionalTableData!
+	
+	override func setUp() {
+		super.setUp()
+		tableView = UITableView()
+		tableModel = FunctionalTableData()
+		tableModel.tableView = tableView
+	}
+	
+	override func tearDown() {
+		tableView = nil
+		tableModel = nil
+		super.tearDown()
+	}
+	
+	// q.v. https://github.com/Shopify/FunctionalTableData/pull/97
+	// Test that cells do not inherit leftover styles from a previous cell config
+	func testCellStyleClearedOnReuse() throws {
+		let disclosureCell = mockCell(key: "cell", style: CellStyle(highlight: true, accessoryType: .disclosureIndicator))
+		let unstyledCell = mockCell(key: "cell", style: nil)
+		
+		var originalCellView: UITableViewCell?
+		
+		let renderedDisclosureCell = expectation(description: "Finished rendering disclosure cell")
+		tableModel.renderAndDiff([TableSection(key: "section", rows: [disclosureCell])], animated: false) {
+			defer {
+				renderedDisclosureCell.fulfill()
+			}
+			
+			guard let cellView = self.tableView.visibleCells.first else {
+				XCTFail("Tableview has no cell views")
+				return
+			}
+			
+			XCTAssertEqual(cellView.accessoryType, .disclosureIndicator)
+			XCTAssertEqual(cellView.selectionStyle, .default)
+			
+			// Keep a reference to check that the same cell view is reused for the new state
+			originalCellView = cellView
+		}
+		
+		wait(for: [renderedDisclosureCell], timeout: 10.0)
+		
+		let renderedUnstyledCell = expectation(description: "Finished rendering unstyled cell")
+		tableModel.renderAndDiff([TableSection(key: "section", rows: [unstyledCell])], animated: false) {
+			defer {
+				renderedUnstyledCell.fulfill()
+			}
+			
+			guard let cellView = self.tableView.visibleCells.first else {
+				XCTFail("Tableview has no cell views")
+				return
+			}
+			
+			XCTAssertEqual(cellView, originalCellView, "Original cell view was not reused")
+			
+			XCTAssertEqual(cellView.accessoryType, .none)
+			XCTAssertEqual(cellView.selectionStyle, .none)
+		}
+		
+		wait(for: [renderedUnstyledCell], timeout: 10.0)
+	}
+	
+	private func mockCell(key: String, style: CellStyle?) -> CellConfigType {
+		return LabelCell(
+			key: key,
+			style: style,
+			state: "",
+			cellUpdater: { _, _ in })
+	}
+}


### PR DESCRIPTION
Whenever a cell gets updated, `FunctionalXData` calculates the "merged" style for that cell (the combination of the cell's style and its section's style) and then asks that style to apply itself to the cell view using `CellStyle.configure(cell:)`

However:

`CellConfigType.style` and `TableSection.style` are optionals that default to `nil`, and when they're both `nil` then `TableSection.mergedStyle(for: cell)` also returns `nil`. **In this case, we don't apply *any* style to the cell and it retains its previous appearance.** This caused previous styles to be 'leaked': e.g. background colors, accessory types etc. could be left over from a previous style.

It also meant that certain default layout properties we assumed were always configured (e.g. `layoutMargins` and `preservesSuperviewLayoutMargins`) might never get applied for cells that don't have styles, causing cell behaviour to be unpredictable.