### PR TITLE
Prevent inlining of HostCell.isEqual

### DIFF
--- a/FunctionalTableData/HostCell.swift
+++ b/FunctionalTableData/HostCell.swift
@@ -93,6 +93,7 @@ public struct HostCell<View, State, Layout>: CellConfigType where View: UIView, 
 		cellUpdater(cell.view, state)
 	}
 	
+	@inline(never)
 	public func isEqual(_ other: CellConfigType) -> Bool {
 		if let other = other as? HostCell<View, State, Layout> {
 			return state == other.state


### PR DESCRIPTION
HostCell isEqual has been causing crashes since Swift 4.1. We don't have a reproducible test case for this, but we have similar crashes caused by the optimizer. As a work around we can tell the isEqual function to never inline and cross our fingers that this crash stops happening.

Example of top of stack from a crash report:
```swift
0  Shopify                 __hidden#21025_ (__hidden#20994_:107:14)
1  Shopify                 isEqual (HostCell.swift:97:24)
2  Shopify                 isRow (TableSectionChangeSet.swift:164:16)
3  Shopify                 isRow (TableSectionChangeSet.swift)
4  Shopify                 calculateChanges (TableSectionChangeSet.swift:137:7)
5  Shopify                 init (TableSectionChangeSet.swift:76:3)
6  Shopify                 calculateTableChanges (FunctionalTableData.swift:465:10)
7  Shopify                 doRenderAndDiff (FunctionalTableData.swift)
```