### PR TITLE
Add hooks for reporting accessibility scroll status

### DIFF
--- a/FunctionalTableData/CollectionView/FunctionalCollectionData.swift
+++ b/FunctionalTableData/CollectionView/FunctionalCollectionData.swift
@@ -85,6 +85,10 @@ public class FunctionalCollectionData: NSObject {
 	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619382-scrollviewdidscrolltotop) for more information.
 	public var scrollViewDidScrollToTop: ((_ scrollView: UIScrollView) -> Void)?
 	
+	/// An optional callback that describes the current scroll position of the collection view as an accessibility aid.
+	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewaccessibilitydelegate/1621055-accessibilityscrollstatus) for more information.
+	public var scrollViewAccessibilityScrollStatus: ((_ scrollView: UIScrollView) -> String?)?
+	
 	private let unitTesting: Bool
 	
 	/// A Boolean value that returns `true` when a `renderAndDiff` pass is currently running.
@@ -581,5 +585,11 @@ extension FunctionalCollectionData: UICollectionViewDelegate {
 	
 	public func scrollViewDidScrollToTop(_ scrollView: UIScrollView) {
 		scrollViewDidScrollToTop?(scrollView)
+	}
+	
+	// MARK: - UIScrollViewAccessibilityDelegate
+	
+	public func accessibilityScrollStatus(for scrollView: UIScrollView) -> String? {
+		return scrollViewAccessibilityScrollStatus?(scrollView)
 	}
 }

--- a/FunctionalTableData/TableView/FunctionalTableData.swift
+++ b/FunctionalTableData/TableView/FunctionalTableData.swift
@@ -105,6 +105,10 @@ public class FunctionalTableData: NSObject {
 	public var scrollViewShouldScrollToTop: ((_ scrollView: UIScrollView) -> Bool)?
 	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619382-scrollviewdidscrolltotop) for more information.
 	public var scrollViewDidScrollToTop: ((_ scrollView: UIScrollView) -> Void)?
+
+	/// An optional callback that describes the current scroll position of the table as an accessibility aid.
+	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewaccessibilitydelegate/1621055-accessibilityscrollstatus) for more information.
+	public var scrollViewAccessibilityScrollStatus: ((_ scrollView: UIScrollView) -> String?)?
 	
 	/// The type of animation when rows and sections are inserted or deleted.
 	public struct TableAnimations {
@@ -779,5 +783,11 @@ extension FunctionalTableData: UITableViewDelegate {
 	
 	public func scrollViewDidScrollToTop(_ scrollView: UIScrollView) {
 		scrollViewDidScrollToTop?(scrollView)
+	}
+	
+	// MARK: - UIScrollViewAccessibilityDelegate
+	
+	public func accessibilityScrollStatus(for scrollView: UIScrollView) -> String? {
+		return scrollViewAccessibilityScrollStatus?(scrollView)
 	}
 }


### PR DESCRIPTION
This PR adds an optional callback for `UIAccessibilityScrollViewDelegate.accessibilityScrollStatus`, which can be used to report the current scroll position of the table in an accessible way: e.g. "Page 2 of 3" (for general screen content), "Aardvark to Marmoset" (for alphabetised lists), "15th January to 23rd March" (for chronological lists) etc. This is a useful navigational aid for VoiceOver users.

This PR also adds a helper method to get all currently-visible cells, which proved useful for constructing these accessibility descriptions.