### PR TITLE
Make FTD and FCD conform to UIScrollViewAccessibilityDelegate

### DIFF
--- a/FunctionalTableData/CollectionView/FunctionalCollectionData.swift
+++ b/FunctionalTableData/CollectionView/FunctionalCollectionData.swift
@@ -586,9 +586,11 @@ extension FunctionalCollectionData: UICollectionViewDelegate {
 	public func scrollViewDidScrollToTop(_ scrollView: UIScrollView) {
 		scrollViewDidScrollToTop?(scrollView)
 	}
-	
-	// MARK: - UIScrollViewAccessibilityDelegate
-	
+}
+
+// MARK: - UIScrollViewAccessibilityDelegate
+
+extension FunctionalCollectionData: UIScrollViewAccessibilityDelegate {
 	public func accessibilityScrollStatus(for scrollView: UIScrollView) -> String? {
 		return scrollViewAccessibilityScrollStatus?(scrollView)
 	}

--- a/FunctionalTableData/TableView/FunctionalTableData.swift
+++ b/FunctionalTableData/TableView/FunctionalTableData.swift
@@ -784,9 +784,11 @@ extension FunctionalTableData: UITableViewDelegate {
 	public func scrollViewDidScrollToTop(_ scrollView: UIScrollView) {
 		scrollViewDidScrollToTop?(scrollView)
 	}
-	
-	// MARK: - UIScrollViewAccessibilityDelegate
-	
+}
+
+// MARK: - UIScrollViewAccessibilityDelegate
+
+extension FunctionalTableData: UIScrollViewAccessibilityDelegate {
 	public func accessibilityScrollStatus(for scrollView: UIScrollView) -> String? {
 		return scrollViewAccessibilityScrollStatus?(scrollView)
 	}


### PR DESCRIPTION
Oops. In https://github.com/Shopify/FunctionalTableData/pull/100 I forgot to make `FunctionalTableData` and `FunctionalCollectionData` actually advertise that they conform to `UIScrollViewAccessibilityDelegate`, which meant `accessibilityScrollStatus` was never called. This PR fixes that.