### PR TITLE
Change changeset to class

### DIFF
--- a/FunctionalTableData/HostCell.swift
+++ b/FunctionalTableData/HostCell.swift
@@ -93,7 +93,6 @@ public struct HostCell<View, State, Layout>: CellConfigType where View: UIView, 
 		cellUpdater(cell.view, state)
 	}
 	
-	@inline(never)
 	public func isEqual(_ other: CellConfigType) -> Bool {
 		if let other = other as? HostCell<View, State, Layout> {
 			return state == other.state

--- a/FunctionalTableData/TableSectionChangeSet.swift
+++ b/FunctionalTableData/TableSectionChangeSet.swift
@@ -19,7 +19,7 @@ struct Moved<T: Equatable>: Equatable {
 
 // Compares two arrays of TableSections and produces the operations
 // required to go from one to the other
-public struct TableSectionChangeSet {
+public class TableSectionChangeSet {
 	typealias MovedSection = Moved<Int>
 	typealias MovedRow = Moved<IndexPath>
 
@@ -102,7 +102,7 @@ public struct TableSectionChangeSet {
 	*
 	* Whenever a section was also in the previous list, we compare the sections and perform the exact same algorithm on the individual rows.
 	*/
-	private mutating func calculateChanges() {
+	private func calculateChanges() {
 		let newSections = Set(new.map { $0.key })
 		var oldSections: [String: Int] = Dictionary(minimumCapacity: old.count)
 		for (oldSectionIndex, oldSection) in old.enumerated() {
@@ -167,7 +167,7 @@ public struct TableSectionChangeSet {
 		return new.section.mergedStyle(for: new.row) == old.section.mergedStyle(for: old.row)
 	}
 
-	private mutating func compareRows(newRows: inout Set<String>, oldRows: inout [String: Int], oldSectionIndex: Int, newSectionIndex: Int) {
+	private func compareRows(newRows: inout Set<String>, oldRows: inout [String: Int], oldSectionIndex: Int, newSectionIndex: Int) {
 		// Clear the set and dictionary, ensuring we keep the capacity to reduce allocations
 		newRows.removeAll(keepingCapacity: true)
 		oldRows.removeAll(keepingCapacity: true)

--- a/FunctionalTableData/TableSectionChangeSet.swift
+++ b/FunctionalTableData/TableSectionChangeSet.swift
@@ -19,7 +19,7 @@ struct Moved<T: Equatable>: Equatable {
 
 // Compares two arrays of TableSections and produces the operations
 // required to go from one to the other
-public class TableSectionChangeSet {
+public final class TableSectionChangeSet {
 	typealias MovedSection = Moved<Int>
 	typealias MovedRow = Moved<IndexPath>
 


### PR DESCRIPTION
Changing `TableSectionChangeSet` from a struct to class.

Since Swift 4.1 we have seen many crashes in `HostCell.isEqual`. None of the crashes make sense, but the crash is a SEGV_ACCERR which implies that multiple threads are accessing the same memory. 

Changing the change set from struct to class and eliminating the mutating functions *_maybe_* makes these crashes go away. 
