### PR TITLE
Fix failing typecast in section validation tests

### DIFF
--- a/FunctionalTableDataTests/TableSectionsValidationTests.swift
+++ b/FunctionalTableDataTests/TableSectionsValidationTests.swift
@@ -37,7 +37,12 @@ class TableSectionsValidationTests: XCTestCase {
 		}, failure: {
 			XCTAssertEqual($0.name, NSExceptionName.internalInconsistencyException)
 			XCTAssertNotNil($0.userInfo as? [String: Any])
-			XCTAssertEqual($0.userInfo!["Duplicates"] as? Set<String>, Set(arrayLiteral: "section1"))
+			
+			if let duplicates = $0.userInfo?["Duplicates"] as? [String] {
+				XCTAssertEqual(Set(duplicates), Set(["section1"]))
+			} else {
+				XCTFail("Missing or malformed user info value for Duplicates")
+			}
 		})
 	}
 	
@@ -53,8 +58,18 @@ class TableSectionsValidationTests: XCTestCase {
 		}, failure: {
 			XCTAssertEqual($0.name, NSExceptionName.internalInconsistencyException)
 			XCTAssertNotNil($0.userInfo as? [String: Any])
-			XCTAssertEqual($0.userInfo!["Section"] as? String, "section2")
-			XCTAssertEqual($0.userInfo!["Duplicates"] as? Set<String>, Set(arrayLiteral: "row1", "row4"))
+			
+			if let section = $0.userInfo?["Section"] as? String {
+				XCTAssertEqual(section, "section2")
+			} else {
+				XCTFail("Missing or malformed user info value for Section")
+			}
+			
+			if let duplicates = $0.userInfo?["Duplicates"] as? [String] {
+				XCTAssertEqual(Set(duplicates), Set(["row1", "row4"]))
+			} else {
+				XCTFail("Missing or malformed user info value for Duplicates")
+			}
 		})
 	}
 	


### PR DESCRIPTION
This PR fixes a conditional cast from `[String]` to `Set<String>` that now (as of Swift 4.2 maybe?) always fails, which was causing a pair of tests to fail.