### PR TITLE
Set cell accessibility identifiers to section+cell keys

### DIFF
--- a/FunctionalTableData/TableView/FunctionalTableData.swift
+++ b/FunctionalTableData/TableView/FunctionalTableData.swift
@@ -541,6 +541,7 @@ extension FunctionalTableData: UITableViewDataSource {
 		let row = indexPath.row
 		let cellConfig = sectionData[row]
 		let cell = cellConfig.dequeueCell(from: tableView, at: indexPath)
+		cell.accessibilityIdentifier = sectionData.sectionKeyPathForRow(row)
 		
 		cellConfig.update(cell: cell, in: tableView)
 		sectionData.mergedStyle(for: row)?.configure(cell: cell, in: tableView)

--- a/FunctionalTableDataTests/FunctionalDataTests.swift
+++ b/FunctionalTableDataTests/FunctionalDataTests.swift
@@ -73,6 +73,25 @@ class FunctionalDataTests: XCTestCase {
 		XCTAssertNotNil(indexPath)
 	}
 	
+	func testCellAccessibilityIdentifiers() {
+		let tableData = FunctionalTableData()
+		let tableView = UITableView()
+		
+		tableData.tableView = tableView
+		let expectation1 = expectation(description: "rendered")
+		let cellConfig = TestCaseCell(key: "cellKey", state: TestCaseState(data: "red"), cellUpdater: TestCaseState.updateView)
+		let section = TableSection(key: "sectionKey", rows: [cellConfig])
+		
+		tableData.renderAndDiff([section]) {
+			expectation1.fulfill()
+		}
+		waitForExpectations(timeout: 1, handler: nil)
+		
+		let cell = tableData.tableView?.visibleCells.first
+		XCTAssertNotNil(cell)
+		XCTAssertEqual(cell!.accessibilityIdentifier, section.sectionKeyPathForRow(0))
+	}
+	
 	func testPerformance() {
 		let functionalData = FunctionalTableData()
 		

--- a/FunctionalTableDataTests/FunctionalDataTests.swift
+++ b/FunctionalTableDataTests/FunctionalDataTests.swift
@@ -88,8 +88,7 @@ class FunctionalDataTests: XCTestCase {
 		waitForExpectations(timeout: 1, handler: nil)
 		
 		let cell = tableData.tableView?.visibleCells.first
-		XCTAssertNotNil(cell)
-		XCTAssertEqual(cell!.accessibilityIdentifier, section.sectionKeyPathForRow(0))
+		XCTAssertEqual(cell?.accessibilityIdentifier, "sectionKeycellKey")
 	}
 	
 	func testPerformance() {


### PR DESCRIPTION
## What

Adds an accessibility identifier to each cell so we can access them more easily for UI Testing. Since we already add unique keys to each section configuration and cell configuration, we should be able to reuse them as the accessibility identifiers. This way we don't have to input any extra identifiers.

If you have two components inside a cell you want to access separately you can set those components as accessibility elements to override the cell's accessibility identifier.

Since accessibility identifiers are only used for UITesting, this shouldn't affect any integrations with Voice Over.

### Example

Similar to the test, if we had a section:
```swift
TableSection(key: "sectionKey", rows: [SomeCell(key: "cellKey")])
```
The `accessibilityIdentifier` of the cell inside that section will be `"sectionKeycellKey"`