### PR TITLE
Fixed background thread access UI component

### DIFF
--- a/FunctionalTableData/CollectionView/FunctionalCollectionData.swift
+++ b/FunctionalTableData/CollectionView/FunctionalCollectionData.swift
@@ -202,7 +202,8 @@ public class FunctionalCollectionData: NSObject {
 					if $0.name == NSExceptionName.internalInconsistencyException {
 						guard let exceptionHandler = FunctionalTableData.exceptionHandler else { return }
 						let changes = TableSectionChangeSet()
-						let exception = FunctionalTableData.Exception(name: $0.name.rawValue, newSections: newSections, oldSections: strongSelf.sections, changes: changes, visible: [], viewFrame: strongSelf.collectionView?.frame ?? .zero, reason: $0.reason, userInfo: $0.userInfo)
+						let viewFrame = DispatchQueue.main.sync { strongSelf.collectionView?.frame ?? .zero }
+						let exception = FunctionalTableData.Exception(name: $0.name.rawValue, newSections: newSections, oldSections: strongSelf.sections, changes: changes, visible: [], viewFrame: viewFrame, reason: $0.reason, userInfo: $0.userInfo)
 						exceptionHandler.handle(exception: exception)
 					}
 				})

--- a/FunctionalTableData/TableView/FunctionalTableData.swift
+++ b/FunctionalTableData/TableView/FunctionalTableData.swift
@@ -265,7 +265,8 @@ public class FunctionalTableData: NSObject {
 					if $0.name == NSExceptionName.internalInconsistencyException {
 						guard let exceptionHandler = FunctionalTableData.exceptionHandler else { return }
 						let changes = TableSectionChangeSet()
-						let exception = Exception(name: $0.name.rawValue, newSections: newSections, oldSections: strongSelf.sections, changes: changes, visible: [], viewFrame: strongSelf.tableView?.frame ?? .zero, reason: $0.reason, userInfo: $0.userInfo)
+						let viewFrame = DispatchQueue.main.sync { strongSelf.tableView?.frame ?? .zero }
+						let exception = Exception(name: $0.name.rawValue, newSections: newSections, oldSections: strongSelf.sections, changes: changes, visible: [], viewFrame: viewFrame, reason: $0.reason, userInfo: $0.userInfo)
 						exceptionHandler.handle(exception: exception)
 					}
 				})


### PR DESCRIPTION
Resolves https://github.com/Shopify/FunctionalTableData/issues/113

The `tableView.frame` was directly accessed in the `BlockOperation`. As suggested by the main thread checker, this should only be accessed in the main thread.