### PR TITLE
 FTD scrolls past the last TableSection

### DIFF
--- a/FunctionalTableData/TableView/FunctionalTableData.swift
+++ b/FunctionalTableData/TableView/FunctionalTableData.swift
@@ -417,6 +417,7 @@ public class FunctionalTableData: NSObject {
 	}
 	
 	private func finishRenderAndDiff() {
+        tableView.layoutIfNeeded()
 		renderAndDiffQueue.isSuspended = false
 	}
 	

--- a/FunctionalTableData/TableView/FunctionalTableData.swift
+++ b/FunctionalTableData/TableView/FunctionalTableData.swift
@@ -417,7 +417,7 @@ public class FunctionalTableData: NSObject {
 	}
 	
 	private func finishRenderAndDiff() {
-        tableView.layoutIfNeeded()
+        tableView?.layoutIfNeeded()
 		renderAndDiffQueue.isSuspended = false
 	}
 	


### PR DESCRIPTION
 A bug in FTD was noticed in the following situation:

- A tableView is loaded with less `TableSection`s than its previous render.
- One way to replicate these findings, is to sign in to two stores. (Testable ViewControllers are stated below)

- 2 ViewControllers where this can be seen: 

1) In the **Marketing Overview Section**

- Reason - `ExternalActivities` is empty for this store, and so that `TableSection` is not rendered.

![simulator screen shot - iphone 7 - 2018-11-05 at 10 42 23](https://user-images.githubusercontent.com/42981240/48008846-754fd200-e0e8-11e8-9396-43be8d36b374.png)

2) In the **Products Overview Section**

- Reason - There are no Out-Of-Stock Products in this store and so that `outOfStockProductsCard` `TableSection` is not rendered

![simulator screen shot - iphone 7 - 2018-11-05 at 10 42 04](https://user-images.githubusercontent.com/42981240/48008852-7bde4980-e0e8-11e8-9e7e-c233f52a2a7e.png)


**Fix**

In `FunctionalTableData`, `reloadData()` is called inside a `CATransaction`. I'm not sure how the core animation is interfering with the `tableView` display, but calling `layoutIfNeeded()` on the `tableView` in the animation's completionBlock seems to render the `tableview` correctly i.e. with the correct scroll length

There might be other ways to solve this and so I'm open changing the fix.