### PR TITLE
Deprecate backgroundView for backgroundViewProvider

### DIFF
--- a/FunctionalTableData.xcodeproj/project.pbxproj
+++ b/FunctionalTableData.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		4CCCE8481F8AA7F400C73258 /* TableItemLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CCCE8471F8AA7F400C73258 /* TableItemLayout.swift */; };
 		4CD535031F9E3A010041A3F9 /* CellStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CD535021F9E3A010041A3F9 /* CellStyleTests.swift */; };
 		9FF97DB3212CA23B006FA047 /* TableCellReuseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FF97DB2212CA23B006FA047 /* TableCellReuseTests.swift */; };
+		BC8C5D4121763B7B00443E28 /* BackgroundViewProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC8C5D4021763B7B00443E28 /* BackgroundViewProvider.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -122,6 +123,7 @@
 		4CCCE8471F8AA7F400C73258 /* TableItemLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableItemLayout.swift; sourceTree = "<group>"; };
 		4CD535021F9E3A010041A3F9 /* CellStyleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellStyleTests.swift; sourceTree = "<group>"; };
 		9FF97DB2212CA23B006FA047 /* TableCellReuseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableCellReuseTests.swift; sourceTree = "<group>"; };
+		BC8C5D4021763B7B00443E28 /* BackgroundViewProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundViewProvider.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -213,6 +215,7 @@
 				4C7A27871F2FB68400360E9B /* Extensions */,
 				4CCCE83E1F8AA7B200C73258 /* CollectionView */,
 				4CCCE8431F8AA7CD00C73258 /* TableView */,
+				BC8C5D4021763B7B00443E28 /* BackgroundViewProvider.swift */,
 				4C7A276F1F2FB55D00360E9B /* CellActions.swift */,
 				4C7A27701F2FB55D00360E9B /* CellConfigType.swift */,
 				4C7A27761F2FB55D00360E9B /* CellStyle.swift */,
@@ -456,6 +459,7 @@
 				3624340420D2F40100A75787 /* Array+TableSection.swift in Sources */,
 				4C7A27861F2FB55D00360E9B /* TableSectionHeaderFooter.swift in Sources */,
 				4C7A277C1F2FB55D00360E9B /* CellConfigType.swift in Sources */,
+				BC8C5D4121763B7B00443E28 /* BackgroundViewProvider.swift in Sources */,
 				4C7A27811F2FB55D00360E9B /* Separator.swift in Sources */,
 				4C7A277F1F2FB55D00360E9B /* ObjCExceptionRethrower.swift in Sources */,
 				4C7A27891F2FB69C00360E9B /* UIView+AutoLayout.swift in Sources */,

--- a/FunctionalTableData/BackgroundViewProvider.swift
+++ b/FunctionalTableData/BackgroundViewProvider.swift
@@ -1,0 +1,20 @@
+//
+//  BackgroundViewProvider.swift
+//  FunctionalTableData
+//
+//  Created by Scott Campbell on 2018-10-16.
+//  Copyright © 2018 Shopify. All rights reserved.
+//
+
+import UIKit
+
+/// Provide a background view to be displayed behind the other contents of a cell.
+/// An implementation should maintain some internal state about the contents of the view.
+public protocol BackgroundViewProvider {
+	/// This is where the background view should be instantiated, since this
+	/// function is only called when a cell is being prepared to be dequeued.
+	func backgroundView() -> UIView?
+
+	/// Compare the internal state to avoid unnecessarily instantiating the background view.
+	func isEqualTo(_ other: BackgroundViewProvider?) -> Bool
+}

--- a/FunctionalTableData/CellStyle.swift
+++ b/FunctionalTableData/CellStyle.swift
@@ -54,8 +54,11 @@ public struct CellStyle {
 	public var selectionColor: UIColor?
 	/// The view's background color.
 	public var backgroundColor: UIColor?
-	/// The view that is displayed behind the cell’s other content.
+	/// The view that is displayed behind the cell's other content.
+	@available(*, deprecated, message: "Replaced with backgroundViewProvider.")
 	public var backgroundView: UIView?
+	/// Provides the view that is displayed behind the cell's other content.
+	public var backgroundViewProvider: BackgroundViewProvider?
 	/// The tint color to apply to the cell.
 	public var tintColor: UIColor?
 	/// The default spacing to use when laying out content in the view.
@@ -63,6 +66,7 @@ public struct CellStyle {
 	/// The radius to use when drawing rounded corners in the view.
 	public var cornerRadius: CGFloat
 	
+	@available(*, deprecated, message: "The `backgroundView` argument is no longer available. Use backgroundViewProvider instead.")
 	public init(topSeparator: Separator.Style? = nil,
 	            bottomSeparator: Separator.Style? = nil,
 	            separatorColor: UIColor? = nil,
@@ -70,7 +74,7 @@ public struct CellStyle {
 	            accessoryType: UITableViewCell.AccessoryType = .none,
 	            selectionColor: UIColor? = CellStyle.defaultSelectionColor,
 	            backgroundColor: UIColor? = CellStyle.defaultBackgroundColor,
-	            backgroundView: UIView? = nil,
+	            backgroundView: UIView?,
 	            tintColor: UIColor? = nil,
 	            layoutMargins: UIEdgeInsets? = nil,
 	            cornerRadius: CGFloat = 0) {
@@ -81,7 +85,44 @@ public struct CellStyle {
 		self.accessoryType = accessoryType
 		self.selectionColor = selectionColor
 		self.backgroundColor = backgroundColor
-		self.backgroundView = backgroundView
+		self.tintColor = tintColor
+		self.layoutMargins = layoutMargins
+		self.cornerRadius = cornerRadius
+
+		struct DefaultBackgroundProvider: BackgroundViewProvider {
+			let view: UIView?
+
+			func backgroundView() -> UIView? {
+				return view
+			}
+
+			func isEqualTo(_ other: BackgroundViewProvider?) -> Bool {
+				return backgroundView() == other?.backgroundView()
+			}
+		}
+
+		self.backgroundViewProvider = DefaultBackgroundProvider(view: backgroundView)
+	}
+
+	public init(topSeparator: Separator.Style? = nil,
+				bottomSeparator: Separator.Style? = nil,
+				separatorColor: UIColor? = nil,
+				highlight: Bool? = nil,
+				accessoryType: UITableViewCell.AccessoryType = .none,
+				selectionColor: UIColor? = CellStyle.defaultSelectionColor,
+				backgroundColor: UIColor? = CellStyle.defaultBackgroundColor,
+				backgroundViewProvider: BackgroundViewProvider? = nil,
+				tintColor: UIColor? = nil,
+				layoutMargins: UIEdgeInsets? = nil,
+				cornerRadius: CGFloat = 0) {
+		self.bottomSeparator = bottomSeparator
+		self.topSeparator = topSeparator
+		self.separatorColor = separatorColor
+		self.highlight = highlight
+		self.accessoryType = accessoryType
+		self.selectionColor = selectionColor
+		self.backgroundColor = backgroundColor
+		self.backgroundViewProvider = backgroundViewProvider
 		self.tintColor = tintColor
 		self.layoutMargins = layoutMargins
 		self.cornerRadius = cornerRadius
@@ -89,8 +130,8 @@ public struct CellStyle {
 	
 	func configure(cell: UICollectionViewCell, in collectionView: UICollectionView) {
 		cell.backgroundColor = backgroundColor
-		cell.backgroundView = backgroundView
-		
+		cell.backgroundView = backgroundViewProvider?.backgroundView()
+
 		if let layoutMargins = layoutMargins {
 			cell.contentView.layoutMargins = layoutMargins
 		}
@@ -126,9 +167,9 @@ public struct CellStyle {
 		} else {
 			cell.removeSeparator(Separator.Tag.top)
 		}
-		
+
 		cell.backgroundColor = backgroundColor
-		cell.backgroundView = backgroundView
+		cell.backgroundView = backgroundViewProvider?.backgroundView()
 		
 		// SUPER HACK! On iOS 11, setting preserveSuperviewLayoutMargin to true changes the behavior
 		// of the layout margins, even when it was already true. Without this fix our layout margins
@@ -163,10 +204,10 @@ extension CellStyle: Equatable {
 		equality = equality && lhs.accessoryType == rhs.accessoryType
 		equality = equality && lhs.selectionColor == rhs.selectionColor
 		equality = equality && lhs.backgroundColor == rhs.backgroundColor
-		equality = equality && lhs.backgroundView == rhs.backgroundView
 		equality = equality && lhs.tintColor == rhs.tintColor
 		equality = equality && lhs.layoutMargins == rhs.layoutMargins
 		equality = equality && lhs.cornerRadius == rhs.cornerRadius
+		equality = equality && lhs.backgroundViewProvider?.isEqualTo(rhs.backgroundViewProvider) ?? (rhs.backgroundViewProvider == nil)
 		return equality
 	}
 }

--- a/FunctionalTableDataTests/CellStyleTests.swift
+++ b/FunctionalTableDataTests/CellStyleTests.swift
@@ -13,6 +13,21 @@ class StyleTests: XCTestCase {
 	var cell: UITableViewCell!
 	var table: UITableView!
 	var style: CellStyle!
+
+	struct ColoredBackgroundProvider: BackgroundViewProvider {
+		let color: UIColor
+
+		public func backgroundView() -> UIView? {
+			let bgView = UIView()
+			bgView.backgroundColor = color
+			return bgView
+		}
+
+		public func isEqualTo(_ other: BackgroundViewProvider?) -> Bool {
+			guard let other = other as? ColoredBackgroundProvider else { return false }
+			return color == other.color
+		}
+	}
 	
 	override func setUp() {
 		super.setUp()
@@ -119,31 +134,19 @@ class StyleTests: XCTestCase {
 	
 	func testBackground() {
 		style.configure(cell: cell, in: table)
-		XCTAssertNil(cell.backgroundView)
 		XCTAssertEqual(cell.backgroundColor, CellStyle.defaultBackgroundColor)
-		
 		style.backgroundColor = .red
 		style.configure(cell: cell, in: table)
-		XCTAssertNil(cell.backgroundView)
 		XCTAssertEqual(cell.backgroundColor, .red)
-		
-		let bgView = UIView()
-		bgView.backgroundColor = .yellow
-		style.backgroundView = bgView
+		let backgroundViewProvider = ColoredBackgroundProvider(color: .yellow)
+		style.backgroundViewProvider = backgroundViewProvider
 		style.configure(cell: cell, in: table)
-		XCTAssertEqual(cell.backgroundView, bgView)
 		XCTAssertEqual(cell.backgroundView?.backgroundColor, .yellow)
-		XCTAssertEqual(cell.backgroundColor, .red)
-		
-		style.backgroundView = nil
-		style.configure(cell: cell, in: table)
-		XCTAssertNil(cell.backgroundView)
-		XCTAssertEqual(cell.backgroundColor, .red)
-		
+		style.backgroundViewProvider = nil
 		style.backgroundColor = nil
 		style.configure(cell: cell, in: table)
-		XCTAssertNil(cell.backgroundView)
 		XCTAssertNil(cell.backgroundColor)
+		XCTAssertNil(cell.backgroundView?.backgroundColor)
 	}
 	
 	func testTintColor() {


### PR DESCRIPTION
Re-opening this as changes have been pushed to the old branch since `stalebot` killed the PR.

The `backgroundView` property on `CellStyle` is expensive - background views are created on every render pass, even though they are rarely used. 

The `BackgroundViewProvider` allows `CellStyle` to request an optional background view when its being dequeued; the only time it's actually needed. 

Fixes https://github.com/Shopify/FunctionalTableData/issues/105