### PR TITLE
Include section header state changes in sections diff

### DIFF
--- a/FunctionalTableData/TableSectionChangeSet.swift
+++ b/FunctionalTableData/TableSectionChangeSet.swift
@@ -134,7 +134,11 @@ public final class TableSectionChangeSet {
 				if oldSectionIndex < old.count && new[newSectionIndex].key == old[oldSectionIndex].key {
 					// Skip over equal sections
 					repeat {
-						compareRows(newRows: &newRows, oldRows: &oldRows, oldSectionIndex: oldSectionIndex, newSectionIndex: newSectionIndex)
+						if headerOrFooterChanged(oldSectionIndex: oldSectionIndex, newSectionIndex: newSectionIndex) {
+							reloadedSections.insert(newSectionIndex)
+						} else {
+							compareRows(newRows: &newRows, oldRows: &oldRows, oldSectionIndex: oldSectionIndex, newSectionIndex: newSectionIndex)
+						}
 						oldSectionIndex += 1
 						newSectionIndex += 1
 					} while oldSectionIndex < old.count &&
@@ -165,6 +169,22 @@ public final class TableSectionChangeSet {
 			return false
 		}
 		return new.section.mergedStyle(for: new.row) == old.section.mergedStyle(for: old.row)
+	}
+
+	private func headerOrFooterChanged(oldSectionIndex: Int, newSectionIndex: Int) -> Bool {
+		let oldHeader = old[oldSectionIndex].header
+		let newHeader = new[newSectionIndex].header
+		guard oldHeader?.isEqual(newHeader) ?? (newHeader == nil) else {
+			return true
+		}
+
+		let oldFooter = old[oldSectionIndex].footer
+		let newFooter = new[newSectionIndex].footer
+		guard oldFooter?.isEqual(newFooter) ?? (newFooter == nil) else {
+			return true
+		}
+
+		return false
 	}
 
 	private func compareRows(newRows: inout Set<String>, oldRows: inout [String: Int], oldSectionIndex: Int, newSectionIndex: Int) {

--- a/FunctionalTableData/TableSectionHeaderFooter.swift
+++ b/FunctionalTableData/TableSectionHeaderFooter.swift
@@ -15,7 +15,14 @@ public typealias TableHeaderConfigType = TableHeaderFooterConfigType
 
 public protocol TableHeaderFooterConfigType: TableItemConfigType {
 	func dequeueHeaderFooter(from tableView: UITableView) -> UITableViewHeaderFooterView?
+	func isEqual(_ other: TableHeaderFooterConfigType?) -> Bool
 	var height: CGFloat { get }
+}
+
+public extension TableHeaderFooterConfigType {
+	func isEqual(_ other: TableHeaderFooterConfigType?) -> Bool {
+		return (other as? Self) != nil
+	}
 }
 
 public protocol TableHeaderFooterStateType {

--- a/FunctionalTableDataTests/TableSectionChangeSetTests.swift
+++ b/FunctionalTableDataTests/TableSectionChangeSetTests.swift
@@ -63,6 +63,90 @@ class TableSectionChangeSetTests: XCTestCase {
 		XCTAssertEqual(changes.deletedSections, IndexSet())
 	}
 
+	func testSectionNotReloadedWithEqualHeaders() {
+		let oldItems: [TableSection] = [TableSection(key: "section1", header: TestHeaderFooter(state: TestHeaderFooterState(data: "green")))]
+		let newItems: [TableSection] = [TableSection(key: "section1", header: TestHeaderFooter(state: TestHeaderFooterState(data: "green")))]
+		let changes = TableSectionChangeSet(old: oldItems, new: newItems, visibleIndexPaths: [])
+
+		XCTAssertTrue(changes.isEmpty)
+		XCTAssertEqual(changes.movedSections, [])
+		XCTAssertEqual(changes.insertedSections, IndexSet())
+		XCTAssertEqual(changes.reloadedSections, IndexSet())
+		XCTAssertEqual(changes.deletedSections, IndexSet())
+	}
+
+	func testSectionNotReloadedWithEqualFooters() {
+		let oldItems: [TableSection] = [TableSection(key: "section1", footer: TestHeaderFooter(state: TestHeaderFooterState(data: "blue")))]
+		let newItems: [TableSection] = [TableSection(key: "section1", footer: TestHeaderFooter(state: TestHeaderFooterState(data: "blue")))]
+		let changes = TableSectionChangeSet(old: oldItems, new: newItems, visibleIndexPaths: [])
+
+		XCTAssertTrue(changes.isEmpty)
+		XCTAssertEqual(changes.movedSections, [])
+		XCTAssertEqual(changes.insertedSections, IndexSet())
+		XCTAssertEqual(changes.reloadedSections, IndexSet())
+		XCTAssertEqual(changes.deletedSections, IndexSet())
+	}
+
+	func testRowsComparedIfHeadersEqual() {
+		let oldItems: [TableSection] = [TableSection(key: "section1", header: TestHeaderFooter(state: TestHeaderFooterState(data: "blue")))]
+		let newItems: [TableSection] = [TableSection(key: "section1", rows: [
+			TestCaseCell(key: "row1", state: TestCaseState(data: "red"), cellUpdater: TestCaseState.updateView)
+			], header: TestHeaderFooter(state: TestHeaderFooterState(data: "blue"))
+		)]
+		let changes = TableSectionChangeSet(old: oldItems, new: newItems, visibleIndexPaths: [])
+
+		XCTAssertFalse(changes.isEmpty)
+		XCTAssertEqual(changes.count, 1)
+		XCTAssertEqual(changes.reloadedSections, IndexSet())
+		XCTAssertEqual(changes.insertedRows, [IndexPath(item: 0, section: 0)])
+	}
+
+	func testSectionReloadedWithInequalHeaders() {
+		let oldItems: [TableSection] = [TableSection(key: "section1", rows: [
+			TestCaseCell(key: "row1", state: TestCaseState(data: "red"), cellUpdater: TestCaseState.updateView)
+			], header: TestHeaderFooter(state: TestHeaderFooterState(data: "green"))
+		)]
+		let newItems: [TableSection] = [TableSection(key: "section1", rows: [
+			TestCaseCell(key: "row1", state: TestCaseState(data: "red"), cellUpdater: TestCaseState.updateView),
+			TestCaseCell(key: "row2", state: TestCaseState(data: "blue"), cellUpdater: TestCaseState.updateView)
+			], header: TestHeaderFooter(state: TestHeaderFooterState(data: "purple"))
+		)]
+		let changes = TableSectionChangeSet(old: oldItems, new: newItems, visibleIndexPaths: [])
+
+		XCTAssertFalse(changes.isEmpty)
+		XCTAssertEqual(changes.count, 1)
+		XCTAssertEqual(changes.movedSections, [])
+		XCTAssertEqual(changes.insertedSections, IndexSet())
+		XCTAssertEqual(changes.reloadedSections, IndexSet([0]))
+		XCTAssertEqual(changes.deletedSections, IndexSet())
+		XCTAssertEqual(changes.insertedRows, [])
+		XCTAssertEqual(changes.deletedRows, [])
+		XCTAssertEqual(changes.reloadedRows, [])
+	}
+
+	func testSectionReloadedWithInequalFooters() {
+		let oldItems: [TableSection] = [TableSection(key: "section1", rows: [
+			TestCaseCell(key: "row1", state: TestCaseState(data: "red"), cellUpdater: TestCaseState.updateView),
+			TestCaseCell(key: "row2", state: TestCaseState(data: "blue"), cellUpdater: TestCaseState.updateView)
+			], footer: TestHeaderFooter(state: TestHeaderFooterState(data: "green"))
+		)]
+		let newItems: [TableSection] = [TableSection(key: "section1", rows: [
+			TestCaseCell(key: "row3", state: TestCaseState(data: "pink"), cellUpdater: TestCaseState.updateView)
+			], footer: TestHeaderFooter(state: TestHeaderFooterState(data: "purple"))
+		)]
+		let changes = TableSectionChangeSet(old: oldItems, new: newItems, visibleIndexPaths: [])
+
+		XCTAssertFalse(changes.isEmpty)
+		XCTAssertEqual(changes.count, 1)
+		XCTAssertEqual(changes.movedSections, [])
+		XCTAssertEqual(changes.insertedSections, IndexSet())
+		XCTAssertEqual(changes.reloadedSections, IndexSet([0]))
+		XCTAssertEqual(changes.deletedSections, IndexSet())
+		XCTAssertEqual(changes.insertedRows, [])
+		XCTAssertEqual(changes.deletedRows, [])
+		XCTAssertEqual(changes.reloadedRows, [])
+	}
+
 	// Shows the algorithm is greedy
 	func testMoveDown() {
 		let oldItems: [TableSection] = [
@@ -456,3 +540,33 @@ class TableSectionChangeSetTests: XCTestCase {
 }
 
 fileprivate typealias LabelCell = HostCell<UILabel, String, LayoutMarginsTableItemLayout>
+
+fileprivate struct TestHeaderFooterState: TableHeaderFooterStateType, Equatable {
+	let insets: UIEdgeInsets = .zero
+	let height: CGFloat = 0
+	let topSeparatorHidden: Bool = true
+	let bottomSeparatorHidden: Bool = true
+	var data: String
+}
+
+fileprivate struct TestHeaderFooter: TableHeaderFooterConfigType {
+	typealias HeaderFooter = TableHeaderFooter<UIView, LayoutMarginsTableItemLayout>
+	let state: TestHeaderFooterState?
+
+	func register(with tableView: UITableView) {
+		tableView.registerReusableHeaderFooterView(HeaderFooter.self)
+	}
+
+	func dequeueHeaderFooter(from tableView: UITableView) -> UITableViewHeaderFooterView? {
+		return tableView.dequeueReusableHeaderFooterView(HeaderFooter.self)
+	}
+
+	func isEqual(_ other: TableHeaderFooterConfigType?) -> Bool {
+		guard let other = other as? TestHeaderFooter else { return false }
+		return state == other.state
+	}
+
+	var height: CGFloat {
+		return state?.height ?? 0
+	}
+}


### PR DESCRIPTION
**Problem**
The state of a `TableSection`s header/footer is not considered in the tableView diff. This means that changes to a header or footer's state will not cause its `TableSection` to be reloaded during a `renderAndDiff`.

 **Solution**
Add `isEqual(...) -> Bool` to the `TableHeaderFooterConfigType` protocol. This allows our conforming types to define what equality means. There is also an extension with a default implementation so that these changes are not breaking - simply check to make sure the types match.

A header/footers updater is only called when a header/footer is dequeued. The only way to ensure a header/footer is dequeued is to reload the table section it belongs to. So, when building the change set:
1. If the section has been deleted, inserted, or moved, this case is irrelevant (the section will go away, or its contents will be dequeued).
2. If the section is in the same position the logic becomes: 
```
if footer has changed or header has changed {
    // The header/footer has changed so we need to reload the whole section in order to update its view. 
    // Skip building the rows changeSet, because all rows will be updated anyways.
} else {
    // The header/footers state has not changed, so compareRows(...) as normal.
}
```

**Potential drawbacks**
Case: We have a section with an arbitrarily large number of rows. There are no state changes for any of the rows, but the header's state has changed. In this instance, reload the entire section in order to update the headers view. I still think this is the appropriate action, as the header is a defining characteristic of the section; if the header changes, we would expect the section to be reloaded.

**Example of implementation** 
In this example, we can construct a section header/footer with a view and state that is not purely decorative. Changes to the headers/footers state will cause the section to reload, so the view is updated accordingly.

```swift
struct CustomHeaderState: TableHeaderFooterStateType, Equatable {
        let insets: UIEdgeInsets
        let topSeparatorHidden: Bool
        let bottomSeparatorHidden: Bool
        let height: CGFloat

        // Any additional stuff thats important for your custom state
        let foo: Int
        let bar: Int
}

struct CustomHeaderFooter<ViewType: UIView, Layout: TableItemLayout>: TableHeaderFooterConfigType {
        typealias ViewUpdater = (_ header: TableHeaderFooter<ViewType, Layout>, _ state: CustomHeaderState) -> Void
        let state: CustomHeaderState?
        let updater: ViewUpdater?

        init(state: CustomHeaderState? = nil, updater: ViewUpdater? = nil) {
                self.state = state
                self.updater = updater
        }

       func isEqual(_ other: TableHeaderFooterConfigType?) -> Bool {
                guard let other = other as? CustomHeaderFooter else { return false }
                return state == other.state
        }

        ...
}
```