### PR TITLE
BUG FIX: Inserting wrong index into reloadedSections.

### DIFF
--- a/FunctionalTableData/TableSectionChangeSet.swift
+++ b/FunctionalTableData/TableSectionChangeSet.swift
@@ -135,7 +135,7 @@ public final class TableSectionChangeSet {
 					// Skip over equal sections
 					repeat {
 						if headerOrFooterChanged(oldSectionIndex: oldSectionIndex, newSectionIndex: newSectionIndex) {
-							reloadedSections.insert(newSectionIndex)
+							reloadedSections.insert(oldSectionIndex)
 						} else {
 							compareRows(newRows: &newRows, oldRows: &oldRows, oldSectionIndex: oldSectionIndex, newSectionIndex: newSectionIndex)
 						}

--- a/FunctionalTableDataTests/TableSectionChangeSetTests.swift
+++ b/FunctionalTableDataTests/TableSectionChangeSetTests.swift
@@ -147,6 +147,42 @@ class TableSectionChangeSetTests: XCTestCase {
 		XCTAssertEqual(changes.reloadedRows, [])
 	}
 
+	func testCorrectSectionReloadedWithDelete() {
+		let oldItems: [TableSection] = [
+			TableSection(key: "section1"),
+			TableSection(key: "section2", footer: TestHeaderFooter(state: TestHeaderFooterState(data: "green")))
+		]
+		let newItems: [TableSection] = [TableSection(key: "section2", footer: TestHeaderFooter(state: TestHeaderFooterState(data: "purple")))]
+		let changes = TableSectionChangeSet(old: oldItems, new: newItems, visibleIndexPaths: [])
+
+		XCTAssertFalse(changes.isEmpty)
+		XCTAssertEqual(changes.count, 2)
+		XCTAssertEqual(changes.movedSections, [])
+		XCTAssertEqual(changes.insertedSections, IndexSet())
+		XCTAssertEqual(changes.reloadedSections, IndexSet([1]))
+		XCTAssertEqual(changes.deletedSections, IndexSet([0]))
+	}
+
+	func testCorrectSectionReloadedWithInsert() {
+		let oldItems: [TableSection] = [
+			TableSection(key: "section1", footer: TestHeaderFooter(state: TestHeaderFooterState(data: "green"))),
+			TableSection(key: "section2")
+		]
+		let newItems: [TableSection] = [
+			TableSection(key: "section3"),
+			TableSection(key: "section1", footer: TestHeaderFooter(state: TestHeaderFooterState(data: "purple"))),
+			TableSection(key: "section2")
+		]
+		let changes = TableSectionChangeSet(old: oldItems, new: newItems, visibleIndexPaths: [])
+
+		XCTAssertFalse(changes.isEmpty)
+		XCTAssertEqual(changes.count, 2)
+		XCTAssertEqual(changes.movedSections, [])
+		XCTAssertEqual(changes.insertedSections, IndexSet([0]))
+		XCTAssertEqual(changes.reloadedSections, IndexSet([0]))
+		XCTAssertEqual(changes.deletedSections, IndexSet())
+	}
+
 	// Shows the algorithm is greedy
 	func testMoveDown() {
 		let oldItems: [TableSection] = [


### PR DESCRIPTION
### Issue: 
The wrong index was inserted into `reloadedSections` in the `TableSectionChangeSet`. This should have been `oldSectionIndex` and not `newSectionIndex` 😓

### Errors:
1. `NSInternalInconsistencyException: Attempt to delete and reload the same index path`
```
OLD [ A, B, C, D ]  // Delete B; Reload C
NEW [ A, C, D ]

Expected change set:
deletedSections = [ 1 ]
reloadedSections = [ 2 ]

Actual change set:
deletedSections = [ 1 ]
reloadedSections = [ 1 ]
```

2. `NSInternalInconsistencyException: Attempt to delete section x, but there are only x sections before the update `
```
OLD = [ A ]  // Insert B; Reload A
NEW = [ B, A ]

Expected change set: 
insertedSections = [ 0 ]
reloadedSections = [ 0 ]

Actual change set:
insertedSections = [ 0 ]
reloadedSections = [ 1 ]  // OLD[1] doesn't exist.
```

## Fix:
- Insert `oldSectionIndex` into `reloadedSections` instead of `newSectionIndex`.
- Unit tests that cover the two cases outlined above. When `newSectionIndex` is used, both of these tests fail.