### PR TITLE
TableSectionHeaderFooter / HostCell parity

### DIFF
--- a/FunctionalTableData/TableSectionHeaderFooter.swift
+++ b/FunctionalTableData/TableSectionHeaderFooter.swift
@@ -14,9 +14,10 @@ import UIKit
 public typealias TableHeaderConfigType = TableHeaderFooterConfigType
 
 public protocol TableHeaderFooterConfigType: TableItemConfigType {
+	var height: CGFloat { get }
 	func dequeueHeaderFooter(from tableView: UITableView) -> UITableViewHeaderFooterView?
 	func isEqual(_ other: TableHeaderFooterConfigType?) -> Bool
-	var height: CGFloat { get }
+	func debugInfo() -> [String: Any]
 }
 
 public protocol TableHeaderFooterStateType: Equatable {
@@ -29,8 +30,12 @@ public protocol TableHeaderFooterStateType: Equatable {
 public struct TableSectionHeaderFooter<View: UIView, Layout: TableItemLayout, State: TableHeaderFooterStateType>: TableHeaderFooterConfigType {
 	public typealias ViewUpdater = (_ header: TableHeaderFooter<View, Layout>, _ state: State) -> Void
 	public let state: State?
-	let viewUpdater: ViewUpdater?
-	
+	public let viewUpdater: ViewUpdater?
+
+	public var height: CGFloat {
+		return state?.height ?? 0
+	}
+
 	public init(state: State? = nil, viewUpdater: ViewUpdater? = nil) {
 		self.state = state
 		self.viewUpdater = viewUpdater
@@ -54,8 +59,12 @@ public struct TableSectionHeaderFooter<View: UIView, Layout: TableItemLayout, St
 		}
 		return false
 	}
-	
-	public var height: CGFloat {
-		return state?.height ?? 0
+
+	public func debugInfo() -> [String: Any] {
+		var debugInfo: [String: Any] = [:]
+		if let state = state {
+			debugInfo["state"] = String(describing: state)
+		}
+		return debugInfo
 	}
 }

--- a/FunctionalTableData/TableSectionHeaderFooter.swift
+++ b/FunctionalTableData/TableSectionHeaderFooter.swift
@@ -19,39 +19,40 @@ public protocol TableHeaderFooterConfigType: TableItemConfigType {
 	var height: CGFloat { get }
 }
 
-public extension TableHeaderFooterConfigType {
-	func isEqual(_ other: TableHeaderFooterConfigType?) -> Bool {
-		return (other as? Self) != nil
-	}
-}
-
-public protocol TableHeaderFooterStateType {
+public protocol TableHeaderFooterStateType: Equatable {
 	var insets: UIEdgeInsets { get }
 	var height: CGFloat { get }
 	var topSeparatorHidden: Bool { get }
 	var bottomSeparatorHidden: Bool { get }
 }
 
-public struct TableSectionHeaderFooter<ViewType: UIView, Layout: TableItemLayout, S: TableHeaderFooterStateType>: TableHeaderFooterConfigType {
-	public typealias ViewUpdater = (_ header: TableHeaderFooter<ViewType, Layout>, _ state: S) -> Void
-	public let state: S?
-	let updateView: ViewUpdater?
+public struct TableSectionHeaderFooter<View: UIView, Layout: TableItemLayout, State: TableHeaderFooterStateType>: TableHeaderFooterConfigType {
+	public typealias ViewUpdater = (_ header: TableHeaderFooter<View, Layout>, _ state: State) -> Void
+	public let state: State?
+	let viewUpdater: ViewUpdater?
 	
-	public init(state: S? = nil, updater: ViewUpdater? = nil) {
+	public init(state: State? = nil, viewUpdater: ViewUpdater? = nil) {
 		self.state = state
-		self.updateView = updater
+		self.viewUpdater = viewUpdater
 	}
 	
 	public func register(with tableView: UITableView) {
-		tableView.registerReusableHeaderFooterView(TableHeaderFooter<ViewType, Layout>.self)
+		tableView.registerReusableHeaderFooterView(TableHeaderFooter<View, Layout>.self)
 	}
 	
 	public func dequeueHeaderFooter(from tableView: UITableView) -> UITableViewHeaderFooterView? {
-		let header = tableView.dequeueReusableHeaderFooterView(TableHeaderFooter<ViewType, Layout>.self)
-		if let updater = updateView, let state = state {
-			updater(header, state)
+		let header = tableView.dequeueReusableHeaderFooterView(TableHeaderFooter<View, Layout>.self)
+		if let viewUpdater = viewUpdater, let state = state {
+			viewUpdater(header, state)
 		}
 		return header
+	}
+
+	public func isEqual(_ other: TableHeaderFooterConfigType?) -> Bool {
+		if let other = other as? TableSectionHeaderFooter<View, Layout, State> {
+			return state == other.state
+		}
+		return false
 	}
 	
 	public var height: CGFloat {

--- a/FunctionalTableDataTests/TableSectionChangeSetTests.swift
+++ b/FunctionalTableDataTests/TableSectionChangeSetTests.swift
@@ -576,33 +576,12 @@ class TableSectionChangeSetTests: XCTestCase {
 }
 
 fileprivate typealias LabelCell = HostCell<UILabel, String, LayoutMarginsTableItemLayout>
+fileprivate typealias TestHeaderFooter = TableSectionHeaderFooter<UIView, LayoutMarginsTableItemLayout, TestHeaderFooterState>
 
-fileprivate struct TestHeaderFooterState: TableHeaderFooterStateType, Equatable {
+fileprivate struct TestHeaderFooterState: TableHeaderFooterStateType {
 	let insets: UIEdgeInsets = .zero
 	let height: CGFloat = 0
 	let topSeparatorHidden: Bool = true
 	let bottomSeparatorHidden: Bool = true
 	var data: String
-}
-
-fileprivate struct TestHeaderFooter: TableHeaderFooterConfigType {
-	typealias HeaderFooter = TableHeaderFooter<UIView, LayoutMarginsTableItemLayout>
-	let state: TestHeaderFooterState?
-
-	func register(with tableView: UITableView) {
-		tableView.registerReusableHeaderFooterView(HeaderFooter.self)
-	}
-
-	func dequeueHeaderFooter(from tableView: UITableView) -> UITableViewHeaderFooterView? {
-		return tableView.dequeueReusableHeaderFooterView(HeaderFooter.self)
-	}
-
-	func isEqual(_ other: TableHeaderFooterConfigType?) -> Bool {
-		guard let other = other as? TestHeaderFooter else { return false }
-		return state == other.state
-	}
-
-	var height: CGFloat {
-		return state?.height ?? 0
-	}
 }


### PR DESCRIPTION
### Proposed Changes
Get `TableSectionHeaderFooter` closer to our `HostCell`.
1. Make `TableHeaderFooterStateType` equatable:   
    - Implement a custom `TableSectionHeaderFooter` with a view, state, and layout in the same way you would a `HostCell`; states compared in the same way.   
    - Remove the need for custom `TableHeaderFooterConfigType`s that only exist to provide custom `isEqual` implementations for non-default headers and footers.   
    - An example of this is the additions/deletions for `TableSectionChangeSetTests.swift`.
2. Add `debugInfo` too `TableHeaderFooterConfigType`:   
    - Carried over from `HostCell` to provide more descriptive logging when debugging state diffs.

### Breaking
Because of protocol additions, these changes are breaking for those who have implemented custom `TableHeaderFooterConfig`s  outside of the default `TableSectionHeaderFooter` that we provide.