### PR TITLE
Abstracted code with protocol in tableview and collection view data.

### DIFF
--- a/FunctionalTableData.xcodeproj/project.pbxproj
+++ b/FunctionalTableData.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		4CA356761F322D7F0081BE90 /* TableSectionStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA356741F322D7F0081BE90 /* TableSectionStyleTests.swift */; };
 		4CCCE8481F8AA7F400C73258 /* TableItemLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CCCE8471F8AA7F400C73258 /* TableItemLayout.swift */; };
 		4CD535031F9E3A010041A3F9 /* CellStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CD535021F9E3A010041A3F9 /* CellStyleTests.swift */; };
+		5FFD6C3622263041002F86F7 /* KeyPathType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FFD6C3522263041002F86F7 /* KeyPathType.swift */; };
 		9FF97DB3212CA23B006FA047 /* TableCellReuseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FF97DB2212CA23B006FA047 /* TableCellReuseTests.swift */; };
 		BC8C5D4121763B7B00443E28 /* BackgroundViewProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC8C5D4021763B7B00443E28 /* BackgroundViewProvider.swift */; };
 /* End PBXBuildFile section */
@@ -122,6 +123,7 @@
 		4CCCE8461F8AA7CD00C73258 /* UITableView+Reusable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+Reusable.swift"; sourceTree = "<group>"; };
 		4CCCE8471F8AA7F400C73258 /* TableItemLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableItemLayout.swift; sourceTree = "<group>"; };
 		4CD535021F9E3A010041A3F9 /* CellStyleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellStyleTests.swift; sourceTree = "<group>"; };
+		5FFD6C3522263041002F86F7 /* KeyPathType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyPathType.swift; sourceTree = "<group>"; };
 		9FF97DB2212CA23B006FA047 /* TableCellReuseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableCellReuseTests.swift; sourceTree = "<group>"; };
 		BC8C5D4021763B7B00443E28 /* BackgroundViewProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundViewProvider.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -220,6 +222,7 @@
 				4C7A27701F2FB55D00360E9B /* CellConfigType.swift */,
 				4C7A27761F2FB55D00360E9B /* CellStyle.swift */,
 				4C7A27721F2FB55D00360E9B /* HostCell.swift */,
+				5FFD6C3522263041002F86F7 /* KeyPathType.swift */,
 				4C7A27731F2FB55D00360E9B /* ObjCExceptionRethrower.swift */,
 				4C7A27741F2FB55D00360E9B /* Reusable.swift */,
 				4C7A27751F2FB55D00360E9B /* Separator.swift */,
@@ -469,6 +472,7 @@
 				4C7A277D1F2FB55D00360E9B /* FunctionalTableData.swift in Sources */,
 				4C7A277E1F2FB55D00360E9B /* HostCell.swift in Sources */,
 				4C63250C1F8AA89D00B2B74B /* TableItemConfigType.swift in Sources */,
+				5FFD6C3622263041002F86F7 /* KeyPathType.swift in Sources */,
 				4C7A27851F2FB55D00360E9B /* TableSectionChangeSet.swift in Sources */,
 				4C6325141F8AA8A400B2B74B /* CollectionItemConfigType.swift in Sources */,
 				4C7A27821F2FB55D00360E9B /* CellStyle.swift in Sources */,

--- a/FunctionalTableData/KeyPathType.swift
+++ b/FunctionalTableData/KeyPathType.swift
@@ -59,8 +59,6 @@ public protocol KeyPathType {
     /// - Returns: The key representation of the supplied `IndexPath`.
     func keyPathForIndexPath(indexPath: IndexPath) -> KeyPath
     
-    func sectionForKey(key: String) -> TableSection?
-    
     /// - Parameter point: The point in the collection/table view’s bounds that you want to test.
     /// - Returns: The keypath of the item at the specified point, or `nil` if no item was found at that point.
     func keyPath(at point: CGPoint) -> KeyPath?
@@ -112,16 +110,6 @@ extension KeyPathType
         let section = tableSections[indexPath.section]
         let row = keyRowForIndexPath(at: indexPath, in: section)
         return KeyPath(sectionKey: section.key, rowKey: row.key)
-    }
-    
-    public func sectionForKey(key: String) -> TableSection? {
-        for section in tableSections {
-            if section.key == key {
-                return section
-            }
-        }
-        
-        return nil
     }
     
     /// - Parameter point: The point in the collection/table view’s bounds that you want to test.

--- a/FunctionalTableData/KeyPathType.swift
+++ b/FunctionalTableData/KeyPathType.swift
@@ -1,0 +1,144 @@
+//
+//  KeyPathType.swift
+//  FunctionalTableData
+//
+//  Created by Alex Liu on 2019-02-26.
+//  Copyright © 2019 Shopify. All rights reserved.
+//
+
+import Foundation
+
+/// Represents the unique path to a given item in the `FunctionalCollectionData` or `FunctionalTableData`.
+///
+/// Think of it as a readable implementation of `IndexPath`, that can be used to locate a given cell
+/// or `TableSection` in the data set.
+public struct KeyPath: Equatable {
+    /// Unique identifier for a section.
+    public let sectionKey: String
+    /// Unique identifier for an item inside a section.
+    public let rowKey: String
+    
+    public init(sectionKey: String, rowKey: String) {
+        self.sectionKey = sectionKey
+        self.rowKey = rowKey
+    }
+    
+    public static func ==(lhs: KeyPath, rhs: KeyPath) -> Bool {
+        return lhs.sectionKey == rhs.sectionKey && lhs.rowKey == rhs.rowKey
+    }
+}
+
+public protocol KeyPathType {
+    var tableSections: [TableSection] { get }
+    
+    /// Returns the IndexPath of the item at the specified point, or `nil` if no item was found at that point.
+    ///
+    /// - Parameter point: The point in the collection/table view’s bounds that you want to test.
+    /// - Returns: The keypath of the item at the specified point, or `nil` if no item was found at that point.
+    func indexPathForRow(at point: CGPoint) -> IndexPath?
+    func keyRowForIndexPath(at indexPath: IndexPath, in section: TableSection) -> CellConfigType
+    func keyIndexPath(at row: Int, in section: Int) -> IndexPath
+    
+    /// Returns the cell identified by a key path.
+    ///
+    /// - Parameter keyPath: A key path identifying the cell to look up.
+    /// - Returns: A `CellConfigType` instance corresponding to the key path or `nil` if the key path is invalid.
+    func rowForKeyPath(_ keyPath: KeyPath) -> CellConfigType?
+    
+    /// Returns the key path specified by its string presentation.
+    ///
+    /// - Parameter key: String identifier to lookup.
+    /// - Returns: A `KeyPath` that matches the key or `nil` if there is no match.
+    func keyPathForRowKey(_ key: String) -> KeyPath?
+    
+    /// Returns the key path of the cell in a given `IndexPath` location.
+    ///
+    /// __Note:__ This method performs an unsafe lookup, make sure that the `IndexPath` exists
+    /// before trying to transform it into a `KeyPath`.
+    /// - Parameter indexPath: A key path identifying where the key path is located.
+    /// - Returns: The key representation of the supplied `IndexPath`.
+    func keyPathForIndexPath(indexPath: IndexPath) -> KeyPath
+    
+    func sectionForKey(key: String) -> TableSection?
+    
+    /// - Parameter point: The point in the collection/table view’s bounds that you want to test.
+    /// - Returns: The keypath of the item at the specified point, or `nil` if no item was found at that point.
+    func keyPath(at point: CGPoint) -> KeyPath?
+    
+    /// Returns the IndexPath corresponding to the provided KeyPath.
+    ///
+    /// - Parameter keyPath: The path representing the desired indexPath.
+    /// - Returns: The IndexPath of the item at the provided keyPath.
+    func indexPathFromKeyPath(_ keyPath: KeyPath) -> IndexPath?
+}
+
+extension KeyPathType
+{
+    /// Returns the cell identified by a key path.
+    ///
+    /// - Parameter keyPath: A key path identifying the cell to look up.
+    /// - Returns: A `CellConfigType` instance corresponding to the key path or `nil` if the key path is invalid.
+    public func rowForKeyPath(_ keyPath: KeyPath) -> CellConfigType? {
+        if let sectionIndex = tableSections.index(where: { $0.key == keyPath.sectionKey }), let rowIndex = tableSections[sectionIndex].rows.index(where: { $0.key == keyPath.rowKey }) {
+            return tableSections[sectionIndex].rows[rowIndex]
+        }
+        
+        return nil
+    }
+    
+    /// Returns the key path specified by its string presentation.
+    ///
+    /// - Parameter key: String identifier to lookup.
+    /// - Returns: A `KeyPath` that matches the key or `nil` if there is no match.
+    public func keyPathForRowKey(_ key: String) -> KeyPath? {
+        for section in tableSections {
+            for row in section {
+                if row.key == key {
+                    return KeyPath(sectionKey: section.key, rowKey: row.key)
+                }
+            }
+        }
+        
+        return nil
+    }
+    
+    /// Returns the key path of the cell in a given `IndexPath` location.
+    ///
+    /// __Note:__ This method performs an unsafe lookup, make sure that the `IndexPath` exists
+    /// before trying to transform it into a `KeyPath`.
+    /// - Parameter indexPath: A key path identifying where the key path is located.
+    /// - Returns: The key representation of the supplied `IndexPath`.
+    public func keyPathForIndexPath(indexPath: IndexPath) -> KeyPath {
+        let section = tableSections[indexPath.section]
+        let row = keyRowForIndexPath(at: indexPath, in: section)
+        return KeyPath(sectionKey: section.key, rowKey: row.key)
+    }
+    
+    public func sectionForKey(key: String) -> TableSection? {
+        for section in tableSections {
+            if section.key == key {
+                return section
+            }
+        }
+        
+        return nil
+    }
+    
+    /// - Parameter point: The point in the collection/table view’s bounds that you want to test.
+    /// - Returns: the keypath of the item at the specified point, or `nil` if no item was found at that point.
+    public func keyPath(at point: CGPoint) -> KeyPath? {
+        guard let indexPath = indexPathForRow(at: point) else {
+            return nil
+        }
+        
+        return keyPathForIndexPath(indexPath: indexPath)
+    }
+    
+    public func indexPathFromKeyPath(_ keyPath: KeyPath) -> IndexPath? {
+        if let sectionIndex = tableSections.index(where: { $0.key == keyPath.sectionKey }), let rowIndex = tableSections[sectionIndex].rows.index(where: { $0.key == keyPath.rowKey }) {
+            return keyIndexPath(at: rowIndex, in: sectionIndex)
+        }
+        
+        return nil
+    }
+}


### PR DESCRIPTION
### Purpose
Remove duplicated `keyPath` implementations in both `collectionview` and `tableviewdata` by abstract them into a protocol. 

### Implementations

1. Added `KeyPathType` protocol into project, abstracted some shared keyPath related function from `collectionViewData` as well as `tableViewData` 
2. Defined some other helper functions that differs in `collectionViewData` and `tableViewData` such as get `keyPath` by item or row. Those helper functions will not be implemented in protocol extension but instead in each either `tableViewData` or `collectionViewData` classes.
3. Added default implementations for those abstracted function by calling helper functions.
4. Moved struct `KeyPath` into a shared place, removed one duplicated in either `collectionViewData` or `tableViewData`.