### PR TITLE
Adds support for setting a UIScrollViewDelegate

### DIFF
--- a/FunctionalTableData.xcodeproj/project.pbxproj
+++ b/FunctionalTableData.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		4CA356761F322D7F0081BE90 /* TableSectionStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA356741F322D7F0081BE90 /* TableSectionStyleTests.swift */; };
 		4CCCE8481F8AA7F400C73258 /* TableItemLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CCCE8471F8AA7F400C73258 /* TableItemLayout.swift */; };
 		4CD535031F9E3A010041A3F9 /* CellStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CD535021F9E3A010041A3F9 /* CellStyleTests.swift */; };
+		6C5F34C12231B91C00D57BEA /* ScrollViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C5F34C02231B91C00D57BEA /* ScrollViewDelegate.swift */; };
 		9FF97DB3212CA23B006FA047 /* TableCellReuseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FF97DB2212CA23B006FA047 /* TableCellReuseTests.swift */; };
 		BC8C5D4121763B7B00443E28 /* BackgroundViewProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC8C5D4021763B7B00443E28 /* BackgroundViewProvider.swift */; };
 /* End PBXBuildFile section */
@@ -122,6 +123,7 @@
 		4CCCE8461F8AA7CD00C73258 /* UITableView+Reusable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+Reusable.swift"; sourceTree = "<group>"; };
 		4CCCE8471F8AA7F400C73258 /* TableItemLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableItemLayout.swift; sourceTree = "<group>"; };
 		4CD535021F9E3A010041A3F9 /* CellStyleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellStyleTests.swift; sourceTree = "<group>"; };
+		6C5F34C02231B91C00D57BEA /* ScrollViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollViewDelegate.swift; sourceTree = "<group>"; };
 		9FF97DB2212CA23B006FA047 /* TableCellReuseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableCellReuseTests.swift; sourceTree = "<group>"; };
 		BC8C5D4021763B7B00443E28 /* BackgroundViewProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundViewProvider.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -212,9 +214,6 @@
 		4C7A27161F2FA10A00360E9B /* Source */ = {
 			isa = PBXGroup;
 			children = (
-				4C7A27871F2FB68400360E9B /* Extensions */,
-				4CCCE83E1F8AA7B200C73258 /* CollectionView */,
-				4CCCE8431F8AA7CD00C73258 /* TableView */,
 				BC8C5D4021763B7B00443E28 /* BackgroundViewProvider.swift */,
 				4C7A276F1F2FB55D00360E9B /* CellActions.swift */,
 				4C7A27701F2FB55D00360E9B /* CellConfigType.swift */,
@@ -222,11 +221,15 @@
 				4C7A27721F2FB55D00360E9B /* HostCell.swift */,
 				4C7A27731F2FB55D00360E9B /* ObjCExceptionRethrower.swift */,
 				4C7A27741F2FB55D00360E9B /* Reusable.swift */,
+				6C5F34C02231B91C00D57BEA /* ScrollViewDelegate.swift */,
 				4C7A27751F2FB55D00360E9B /* Separator.swift */,
 				4CCCE8471F8AA7F400C73258 /* TableItemLayout.swift */,
 				4C7A27781F2FB55D00360E9B /* TableSection.swift */,
 				4C7A27791F2FB55D00360E9B /* TableSectionChangeSet.swift */,
 				4C7A277A1F2FB55D00360E9B /* TableSectionHeaderFooter.swift */,
+				4CCCE83E1F8AA7B200C73258 /* CollectionView */,
+				4C7A27871F2FB68400360E9B /* Extensions */,
+				4CCCE8431F8AA7CD00C73258 /* TableView */,
 			);
 			name = Source;
 			sourceTree = "<group>";
@@ -234,9 +237,9 @@
 		4C7A27871F2FB68400360E9B /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				3624340320D2F40100A75787 /* Array+TableSection.swift */,
 				4C7A27881F2FB69C00360E9B /* UIView+AutoLayout.swift */,
 				4C7A278A1F2FB89400360E9B /* UIView+Extensions.swift */,
-				3624340320D2F40100A75787 /* Array+TableSection.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -449,6 +452,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6C5F34C12231B91C00D57BEA /* ScrollViewDelegate.swift in Sources */,
 				4C7A278B1F2FB89400360E9B /* UIView+Extensions.swift in Sources */,
 				4CCCE8481F8AA7F400C73258 /* TableItemLayout.swift in Sources */,
 				4C63250B1F8AA89B00B2B74B /* TableCell.swift in Sources */,

--- a/FunctionalTableData/CollectionView/FunctionalCollectionData.swift
+++ b/FunctionalTableData/CollectionView/FunctionalCollectionData.swift
@@ -64,30 +64,39 @@ public class FunctionalCollectionData: NSObject {
 		return sections[indexPath]
 	}
 	
-	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619392-scrollviewdidscroll) for more information.
-	public var scrollViewDidScroll: ((_ scrollView: UIScrollView) -> Void)?
-	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619394-scrollviewwillbegindragging) for more information.
-	public var scrollViewWillBeginDragging: ((_ scrollView: UIScrollView) -> Void)?
-	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619385-scrollviewwillenddragging) for more information.
-	public var scrollViewWillEndDragging: ((_ scrollView: UIScrollView, _ velocity: CGPoint, _ targetContentOffset: UnsafeMutablePointer<CGPoint>) -> Void)?
-	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619436-scrollviewdidenddragging) for more information.
-	public var scrollViewDidEndDragging: ((_ scrollView: UIScrollView, _ decelerate: Bool) -> Void)?
-	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619386-scrollviewwillbegindecelerating) for more information.
-	public var scrollViewWillBeginDecelerating: ((_ scrollView: UIScrollView) -> Void)?
-	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619417-scrollviewdidenddecelerating) for more information.
-	public var scrollViewDidEndDecelerating: ((_ scrollView: UIScrollView) -> Void)?
-	/// Tells the delegate that the scroll view has changed its content size.
-	public var scrollViewDidChangeContentSize: ((_ scrollView: UIScrollView) -> Void)?
-	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619379-scrollviewdidendscrollinganimati) for more information.
-	public var scrollViewDidEndScrollingAnimation: ((_ scrollView: UIScrollView) -> Void)?
-	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619378-scrollviewshouldscrolltotop) for more information.
-	public var scrollViewShouldScrollToTop: ((_ scrollView: UIScrollView) -> Bool)?
-	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619382-scrollviewdidscrolltotop) for more information.
-	public var scrollViewDidScrollToTop: ((_ scrollView: UIScrollView) -> Void)?
+	/// An object to receive various [UIScrollViewDelegate](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate) related events
+	public weak var scrollViewDelegate: UIScrollViewDelegate? {
+		didSet {
+			// Reset the delegate, this triggers UITableView and UIScrollView to re-cache their available delegate methods
+			let delegate = collectionView?.delegate
+			collectionView?.delegate = nil
+			collectionView?.delegate = delegate
+		}
+	}
 	
-	/// An optional callback that describes the current scroll position of the collection view as an accessibility aid.
-	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewaccessibilitydelegate/1621055-accessibilityscrollstatus) for more information.
-	public var scrollViewAccessibilityScrollStatus: ((_ scrollView: UIScrollView) -> String?)?
+	internal var backwardsCompatScrollViewDelegate = ScrollViewDelegate()
+	
+	public override func responds(to aSelector: Selector!) -> Bool {
+		if class_respondsToSelector(type(of: self), aSelector) {
+			return true
+		} else if let scrollViewDelegate = scrollViewDelegate, scrollViewDelegate.responds(to: aSelector) {
+			return true
+		} else if backwardsCompatScrollViewDelegate.responds(to: aSelector) {
+			return true
+		}
+		return super.responds(to: aSelector)
+	}
+	
+	public override func forwardingTarget(for aSelector: Selector!) -> Any? {
+		if class_respondsToSelector(type(of: self), aSelector) {
+			return self
+		} else if let scrollViewDelegate = scrollViewDelegate, scrollViewDelegate.responds(to: aSelector) {
+			return scrollViewDelegate
+		} else if backwardsCompatScrollViewDelegate.responds(to: aSelector) {
+			return backwardsCompatScrollViewDelegate
+		}
+		return super.forwardingTarget(for: aSelector)
+	}
 	
 	private let unitTesting: Bool
 	
@@ -530,58 +539,5 @@ extension FunctionalCollectionData: UICollectionViewDelegate {
 	
 	public func collectionView(_ collectionView: UICollectionView, targetIndexPathForMoveFromItemAt originalIndexPath: IndexPath, toProposedIndexPath proposedIndexPath: IndexPath) -> IndexPath {
 		return originalIndexPath.section == proposedIndexPath.section ? proposedIndexPath : originalIndexPath
-	}
-	
-	// MARK: - UIScrollViewDelegate
-	
-	/// This is an undocumented optional `UIScrollViewDelegate` method that is not exposed by the public protocol
-	/// but will still get called on delegates that implement it. Because it is not publicly exposed,
-	/// the Swift 4 compiler will not automatically annotate it as @objc, requiring this manual annotation.
-	@objc public func scrollViewDidChangeContentSize(_ scrollView: UIScrollView) {
-		scrollViewDidChangeContentSize?(scrollView)
-	}
-	
-	public func scrollViewDidScroll(_ scrollView: UIScrollView) {
-		scrollViewDidScroll?(scrollView)
-	}
-	
-	public func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
-		scrollViewWillBeginDragging?(scrollView)
-	}
-	
-	public func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
-		scrollViewWillEndDragging?(scrollView, velocity, targetContentOffset)
-	}
-	
-	public func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
-		scrollViewDidEndDragging?(scrollView, decelerate)
-	}
-	
-	public func scrollViewWillBeginDecelerating(_ scrollView: UIScrollView) {
-		scrollViewWillBeginDecelerating?(scrollView)
-	}
-	
-	public func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-		scrollViewDidEndDecelerating?(scrollView)
-	}
-	
-	public func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
-		scrollViewDidEndScrollingAnimation?(scrollView)
-	}
-	
-	public func scrollViewShouldScrollToTop(_ scrollView: UIScrollView) -> Bool {
-		return scrollViewShouldScrollToTop?(scrollView) ?? true
-	}
-	
-	public func scrollViewDidScrollToTop(_ scrollView: UIScrollView) {
-		scrollViewDidScrollToTop?(scrollView)
-	}
-}
-
-// MARK: - UIScrollViewAccessibilityDelegate
-
-extension FunctionalCollectionData: UIScrollViewAccessibilityDelegate {
-	public func accessibilityScrollStatus(for scrollView: UIScrollView) -> String? {
-		return scrollViewAccessibilityScrollStatus?(scrollView)
 	}
 }

--- a/FunctionalTableData/ScrollViewDelegate.swift
+++ b/FunctionalTableData/ScrollViewDelegate.swift
@@ -1,0 +1,291 @@
+//
+//  ScrollViewDelegate.swift
+//  FunctionalTableData
+//
+//  Created by Geoffrey Foster on 2019-03-07.
+//  Copyright © 2019 Shopify. All rights reserved.
+//
+
+import Foundation
+
+internal class ScrollViewDelegate: NSObject, UIScrollViewDelegate, UIScrollViewAccessibilityDelegate {
+	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619392-scrollviewdidscroll) for more information.
+	var scrollViewDidScroll: ((_ scrollView: UIScrollView) -> Void)?
+	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619394-scrollviewwillbegindragging) for more information.
+	var scrollViewWillBeginDragging: ((_ scrollView: UIScrollView) -> Void)?
+	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619385-scrollviewwillenddragging) for more information.
+	var scrollViewWillEndDragging: ((_ scrollView: UIScrollView, _ velocity: CGPoint, _ targetContentOffset: UnsafeMutablePointer<CGPoint>) -> Void)?
+	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619436-scrollviewdidenddragging) for more information.
+	var scrollViewDidEndDragging: ((_ scrollView: UIScrollView, _ decelerate: Bool) -> Void)?
+	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619386-scrollviewwillbegindecelerating) for more information.
+	var scrollViewWillBeginDecelerating: ((_ scrollView: UIScrollView) -> Void)?
+	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619417-scrollviewdidenddecelerating) for more information.
+	var scrollViewDidEndDecelerating: ((_ scrollView: UIScrollView) -> Void)?
+	/// Tells the delegate that the scroll view has changed its content size.
+	var scrollViewDidChangeContentSize: ((_ scrollView: UIScrollView) -> Void)?
+	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619379-scrollviewdidendscrollinganimati) for more information.
+	var scrollViewDidEndScrollingAnimation: ((_ scrollView: UIScrollView) -> Void)?
+	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619378-scrollviewshouldscrolltotop) for more information.
+	var scrollViewShouldScrollToTop: ((_ scrollView: UIScrollView) -> Bool)?
+	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619382-scrollviewdidscrolltotop) for more information.
+	var scrollViewDidScrollToTop: ((_ scrollView: UIScrollView) -> Void)?
+	
+	/// An optional callback that describes the current scroll position of the table as an accessibility aid.
+	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewaccessibilitydelegate/1621055-accessibilityscrollstatus) for more information.
+	var scrollViewAccessibilityScrollStatus: ((_ scrollView: UIScrollView) -> String?)?
+	
+	/// This is an undocumented optional `UIScrollViewDelegate` method that is not exposed by the public protocol
+	/// but will still get called on delegates that implement it. Because it is not publicly exposed,
+	/// the Swift 4 compiler will not automatically annotate it as @objc, requiring this manual annotation.
+	@objc public func scrollViewDidChangeContentSize(_ scrollView: UIScrollView) {
+		scrollViewDidChangeContentSize?(scrollView)
+	}
+	
+	public func scrollViewDidScroll(_ scrollView: UIScrollView) {
+		scrollViewDidScroll?(scrollView)
+	}
+	
+	public func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+		scrollViewWillBeginDragging?(scrollView)
+	}
+	
+	public func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
+		scrollViewWillEndDragging?(scrollView, velocity, targetContentOffset)
+	}
+	
+	public func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+		scrollViewDidEndDragging?(scrollView, decelerate)
+	}
+	
+	public func scrollViewWillBeginDecelerating(_ scrollView: UIScrollView) {
+		scrollViewWillBeginDecelerating?(scrollView)
+	}
+	
+	public func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+		scrollViewDidEndDecelerating?(scrollView)
+	}
+	
+	public func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
+		scrollViewDidEndScrollingAnimation?(scrollView)
+	}
+	
+	public func scrollViewShouldScrollToTop(_ scrollView: UIScrollView) -> Bool {
+		return scrollViewShouldScrollToTop?(scrollView) ?? true
+	}
+	
+	public func scrollViewDidScrollToTop(_ scrollView: UIScrollView) {
+		scrollViewDidScrollToTop?(scrollView)
+	}
+	
+	public func accessibilityScrollStatus(for scrollView: UIScrollView) -> String? {
+		return scrollViewAccessibilityScrollStatus?(scrollView)
+	}
+}
+
+public extension FunctionalTableData {
+	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619392-scrollviewdidscroll) for more information.
+	public var scrollViewDidScroll: ((_ scrollView: UIScrollView) -> Void)? {
+		get {
+			return backwardsCompatScrollViewDelegate.scrollViewDidScroll
+		}
+		set {
+			backwardsCompatScrollViewDelegate.scrollViewDidScroll = newValue
+		}
+	}
+	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619394-scrollviewwillbegindragging) for more information.
+	public var scrollViewWillBeginDragging: ((_ scrollView: UIScrollView) -> Void)? {
+		get {
+			return backwardsCompatScrollViewDelegate.scrollViewWillBeginDragging
+		}
+		set {
+			backwardsCompatScrollViewDelegate.scrollViewWillBeginDragging = newValue
+		}
+	}
+	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619385-scrollviewwillenddragging) for more information.
+	public var scrollViewWillEndDragging: ((_ scrollView: UIScrollView, _ velocity: CGPoint, _ targetContentOffset: UnsafeMutablePointer<CGPoint>) -> Void)? {
+		get {
+			return backwardsCompatScrollViewDelegate.scrollViewWillEndDragging
+		}
+		set {
+			backwardsCompatScrollViewDelegate.scrollViewWillEndDragging = newValue
+		}
+	}
+	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619436-scrollviewdidenddragging) for more information.
+	public var scrollViewDidEndDragging: ((_ scrollView: UIScrollView, _ decelerate: Bool) -> Void)? {
+		get {
+			return backwardsCompatScrollViewDelegate.scrollViewDidEndDragging
+		}
+		set {
+			backwardsCompatScrollViewDelegate.scrollViewDidEndDragging = newValue
+		}
+	}
+	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619386-scrollviewwillbegindecelerating) for more information.
+	public var scrollViewWillBeginDecelerating: ((_ scrollView: UIScrollView) -> Void)? {
+		get {
+			return backwardsCompatScrollViewDelegate.scrollViewWillBeginDecelerating
+		}
+		set {
+			backwardsCompatScrollViewDelegate.scrollViewWillBeginDecelerating = newValue
+		}
+	}
+	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619417-scrollviewdidenddecelerating) for more information.
+	public var scrollViewDidEndDecelerating: ((_ scrollView: UIScrollView) -> Void)? {
+		get {
+			return backwardsCompatScrollViewDelegate.scrollViewDidEndDecelerating
+		}
+		set {
+			backwardsCompatScrollViewDelegate.scrollViewDidEndDecelerating = newValue
+		}
+	}
+	/// Tells the delegate that the scroll view has changed its content size.
+	public var scrollViewDidChangeContentSize: ((_ scrollView: UIScrollView) -> Void)? {
+		get {
+			return backwardsCompatScrollViewDelegate.scrollViewDidChangeContentSize
+		}
+		set {
+			backwardsCompatScrollViewDelegate.scrollViewDidChangeContentSize = newValue
+		}
+	}
+	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619379-scrollviewdidendscrollinganimati) for more information.
+	public var scrollViewDidEndScrollingAnimation: ((_ scrollView: UIScrollView) -> Void)? {
+		get {
+			return backwardsCompatScrollViewDelegate.scrollViewDidEndScrollingAnimation
+		}
+		set {
+			backwardsCompatScrollViewDelegate.scrollViewDidEndScrollingAnimation = newValue
+		}
+	}
+	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619378-scrollviewshouldscrolltotop) for more information.
+	public var scrollViewShouldScrollToTop: ((_ scrollView: UIScrollView) -> Bool)? {
+		get {
+			return backwardsCompatScrollViewDelegate.scrollViewShouldScrollToTop
+		}
+		set {
+			backwardsCompatScrollViewDelegate.scrollViewShouldScrollToTop = newValue
+		}
+	}
+	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619382-scrollviewdidscrolltotop) for more information.
+	public var scrollViewDidScrollToTop: ((_ scrollView: UIScrollView) -> Void)? {
+		get {
+			return backwardsCompatScrollViewDelegate.scrollViewDidScrollToTop
+		}
+		set {
+			backwardsCompatScrollViewDelegate.scrollViewDidScrollToTop = newValue
+		}
+	}
+	
+	/// An optional callback that describes the current scroll position of the table as an accessibility aid.
+	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewaccessibilitydelegate/1621055-accessibilityscrollstatus) for more information.
+	public var scrollViewAccessibilityScrollStatus: ((_ scrollView: UIScrollView) -> String?)? {
+		get {
+			return backwardsCompatScrollViewDelegate.scrollViewAccessibilityScrollStatus
+		}
+		set {
+			backwardsCompatScrollViewDelegate.scrollViewAccessibilityScrollStatus = newValue
+		}
+	}
+}
+
+public extension FunctionalCollectionData {
+	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619392-scrollviewdidscroll) for more information.
+	public var scrollViewDidScroll: ((_ scrollView: UIScrollView) -> Void)? {
+		get {
+			return backwardsCompatScrollViewDelegate.scrollViewDidScroll
+		}
+		set {
+			backwardsCompatScrollViewDelegate.scrollViewDidScroll = newValue
+		}
+	}
+	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619394-scrollviewwillbegindragging) for more information.
+	public var scrollViewWillBeginDragging: ((_ scrollView: UIScrollView) -> Void)? {
+		get {
+			return backwardsCompatScrollViewDelegate.scrollViewWillBeginDragging
+		}
+		set {
+			backwardsCompatScrollViewDelegate.scrollViewWillBeginDragging = newValue
+		}
+	}
+	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619385-scrollviewwillenddragging) for more information.
+	public var scrollViewWillEndDragging: ((_ scrollView: UIScrollView, _ velocity: CGPoint, _ targetContentOffset: UnsafeMutablePointer<CGPoint>) -> Void)? {
+		get {
+			return backwardsCompatScrollViewDelegate.scrollViewWillEndDragging
+		}
+		set {
+			backwardsCompatScrollViewDelegate.scrollViewWillEndDragging = newValue
+		}
+	}
+	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619436-scrollviewdidenddragging) for more information.
+	public var scrollViewDidEndDragging: ((_ scrollView: UIScrollView, _ decelerate: Bool) -> Void)? {
+		get {
+			return backwardsCompatScrollViewDelegate.scrollViewDidEndDragging
+		}
+		set {
+			backwardsCompatScrollViewDelegate.scrollViewDidEndDragging = newValue
+		}
+	}
+	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619386-scrollviewwillbegindecelerating) for more information.
+	public var scrollViewWillBeginDecelerating: ((_ scrollView: UIScrollView) -> Void)? {
+		get {
+			return backwardsCompatScrollViewDelegate.scrollViewWillBeginDecelerating
+		}
+		set {
+			backwardsCompatScrollViewDelegate.scrollViewWillBeginDecelerating = newValue
+		}
+	}
+	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619417-scrollviewdidenddecelerating) for more information.
+	public var scrollViewDidEndDecelerating: ((_ scrollView: UIScrollView) -> Void)? {
+		get {
+			return backwardsCompatScrollViewDelegate.scrollViewDidEndDecelerating
+		}
+		set {
+			backwardsCompatScrollViewDelegate.scrollViewDidEndDecelerating = newValue
+		}
+	}
+	/// Tells the delegate that the scroll view has changed its content size.
+	public var scrollViewDidChangeContentSize: ((_ scrollView: UIScrollView) -> Void)? {
+		get {
+			return backwardsCompatScrollViewDelegate.scrollViewDidChangeContentSize
+		}
+		set {
+			backwardsCompatScrollViewDelegate.scrollViewDidChangeContentSize = newValue
+		}
+	}
+	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619379-scrollviewdidendscrollinganimati) for more information.
+	public var scrollViewDidEndScrollingAnimation: ((_ scrollView: UIScrollView) -> Void)? {
+		get {
+			return backwardsCompatScrollViewDelegate.scrollViewDidEndScrollingAnimation
+		}
+		set {
+			backwardsCompatScrollViewDelegate.scrollViewDidEndScrollingAnimation = newValue
+		}
+	}
+	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619378-scrollviewshouldscrolltotop) for more information.
+	public var scrollViewShouldScrollToTop: ((_ scrollView: UIScrollView) -> Bool)? {
+		get {
+			return backwardsCompatScrollViewDelegate.scrollViewShouldScrollToTop
+		}
+		set {
+			backwardsCompatScrollViewDelegate.scrollViewShouldScrollToTop = newValue
+		}
+	}
+	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619382-scrollviewdidscrolltotop) for more information.
+	public var scrollViewDidScrollToTop: ((_ scrollView: UIScrollView) -> Void)? {
+		get {
+			return backwardsCompatScrollViewDelegate.scrollViewDidScrollToTop
+		}
+		set {
+			backwardsCompatScrollViewDelegate.scrollViewDidScrollToTop = newValue
+		}
+	}
+	
+	/// An optional callback that describes the current scroll position of the table as an accessibility aid.
+	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewaccessibilitydelegate/1621055-accessibilityscrollstatus) for more information.
+	public var scrollViewAccessibilityScrollStatus: ((_ scrollView: UIScrollView) -> String?)? {
+		get {
+			return backwardsCompatScrollViewDelegate.scrollViewAccessibilityScrollStatus
+		}
+		set {
+			backwardsCompatScrollViewDelegate.scrollViewAccessibilityScrollStatus = newValue
+		}
+	}
+}


### PR DESCRIPTION
This is for use instead of the closure based mechanism

Uses NSObject's forwardingTarget to send UIScrollViewDelegate based messages to a separate object and removes the need for Functional(Table|Collection)Data to implement and forward all of the various UIScrollViewDelegate based messages itself. Backwards compatibility is maintained with a separate internal object that maintains the closures and will call them (so long as a delegate implementing the same method doesn't exist). In future we can remove this backwards compatible support and rely solely on the UIScrollViewDelegate.