### PR TITLE
Moves the datasource/delegate into own files

### DIFF
--- a/FunctionalTableData.xcodeproj/project.pbxproj
+++ b/FunctionalTableData.xcodeproj/project.pbxproj
@@ -46,6 +46,10 @@
 		4CCCE8481F8AA7F400C73258 /* TableItemLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CCCE8471F8AA7F400C73258 /* TableItemLayout.swift */; };
 		4CD535031F9E3A010041A3F9 /* CellStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CD535021F9E3A010041A3F9 /* CellStyleTests.swift */; };
 		6C5F34C12231B91C00D57BEA /* ScrollViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C5F34C02231B91C00D57BEA /* ScrollViewDelegate.swift */; };
+		6C5F34C52232D14B00D57BEA /* FunctionalTableData+UITableViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C5F34C42232D14B00D57BEA /* FunctionalTableData+UITableViewDelegate.swift */; };
+		6C5F34C72232D15500D57BEA /* FunctionalTableData+UITableViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C5F34C62232D15500D57BEA /* FunctionalTableData+UITableViewDataSource.swift */; };
+		6C5F34C92232E8D300D57BEA /* FunctionalCollectionData+UICollectionViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C5F34C82232E8D300D57BEA /* FunctionalCollectionData+UICollectionViewDelegate.swift */; };
+		6C5F34CB2232E99000D57BEA /* FunctionalCollectionData+UICollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C5F34CA2232E99000D57BEA /* FunctionalCollectionData+UICollectionViewDataSource.swift */; };
 		9FF97DB3212CA23B006FA047 /* TableCellReuseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FF97DB2212CA23B006FA047 /* TableCellReuseTests.swift */; };
 		BC8C5D4121763B7B00443E28 /* BackgroundViewProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC8C5D4021763B7B00443E28 /* BackgroundViewProvider.swift */; };
 /* End PBXBuildFile section */
@@ -124,6 +128,10 @@
 		4CCCE8471F8AA7F400C73258 /* TableItemLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableItemLayout.swift; sourceTree = "<group>"; };
 		4CD535021F9E3A010041A3F9 /* CellStyleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellStyleTests.swift; sourceTree = "<group>"; };
 		6C5F34C02231B91C00D57BEA /* ScrollViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollViewDelegate.swift; sourceTree = "<group>"; };
+		6C5F34C42232D14B00D57BEA /* FunctionalTableData+UITableViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FunctionalTableData+UITableViewDelegate.swift"; sourceTree = "<group>"; };
+		6C5F34C62232D15500D57BEA /* FunctionalTableData+UITableViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FunctionalTableData+UITableViewDataSource.swift"; sourceTree = "<group>"; };
+		6C5F34C82232E8D300D57BEA /* FunctionalCollectionData+UICollectionViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FunctionalCollectionData+UICollectionViewDelegate.swift"; sourceTree = "<group>"; };
+		6C5F34CA2232E99000D57BEA /* FunctionalCollectionData+UICollectionViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FunctionalCollectionData+UICollectionViewDataSource.swift"; sourceTree = "<group>"; };
 		9FF97DB2212CA23B006FA047 /* TableCellReuseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableCellReuseTests.swift; sourceTree = "<group>"; };
 		BC8C5D4021763B7B00443E28 /* BackgroundViewProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundViewProvider.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -250,7 +258,9 @@
 				4CCCE83F1F8AA7B200C73258 /* CollectionCell.swift */,
 				4CCCE8421F8AA7B200C73258 /* CollectionItemConfigType.swift */,
 				4CCCE8411F8AA7B200C73258 /* FunctionalCollectionData.swift */,
+				6C5F34C82232E8D300D57BEA /* FunctionalCollectionData+UICollectionViewDelegate.swift */,
 				4CCCE8401F8AA7B200C73258 /* UICollectionView+Reusable.swift */,
+				6C5F34CA2232E99000D57BEA /* FunctionalCollectionData+UICollectionViewDataSource.swift */,
 			);
 			path = CollectionView;
 			sourceTree = "<group>";
@@ -259,6 +269,8 @@
 			isa = PBXGroup;
 			children = (
 				4C7A27711F2FB55D00360E9B /* FunctionalTableData.swift */,
+				6C5F34C62232D15500D57BEA /* FunctionalTableData+UITableViewDataSource.swift */,
+				6C5F34C42232D14B00D57BEA /* FunctionalTableData+UITableViewDelegate.swift */,
 				4CCCE8441F8AA7CD00C73258 /* TableCell.swift */,
 				4CCCE8451F8AA7CD00C73258 /* TableItemConfigType.swift */,
 				4CCCE8461F8AA7CD00C73258 /* UITableView+Reusable.swift */,
@@ -456,6 +468,7 @@
 				4C7A278B1F2FB89400360E9B /* UIView+Extensions.swift in Sources */,
 				4CCCE8481F8AA7F400C73258 /* TableItemLayout.swift in Sources */,
 				4C63250B1F8AA89B00B2B74B /* TableCell.swift in Sources */,
+				6C5F34CB2232E99000D57BEA /* FunctionalCollectionData+UICollectionViewDataSource.swift in Sources */,
 				4C7A27801F2FB55D00360E9B /* Reusable.swift in Sources */,
 				4C63250D1F8AA8A000B2B74B /* UITableView+Reusable.swift in Sources */,
 				4C7A277B1F2FB55D00360E9B /* CellActions.swift in Sources */,
@@ -468,10 +481,13 @@
 				4C7A277F1F2FB55D00360E9B /* ObjCExceptionRethrower.swift in Sources */,
 				4C7A27891F2FB69C00360E9B /* UIView+AutoLayout.swift in Sources */,
 				4C6325121F8AA8A400B2B74B /* UICollectionView+Reusable.swift in Sources */,
+				6C5F34C92232E8D300D57BEA /* FunctionalCollectionData+UICollectionViewDelegate.swift in Sources */,
 				4C6325111F8AA8A400B2B74B /* CollectionCell.swift in Sources */,
 				4C7A27841F2FB55D00360E9B /* TableSection.swift in Sources */,
+				6C5F34C72232D15500D57BEA /* FunctionalTableData+UITableViewDataSource.swift in Sources */,
 				4C7A277D1F2FB55D00360E9B /* FunctionalTableData.swift in Sources */,
 				4C7A277E1F2FB55D00360E9B /* HostCell.swift in Sources */,
+				6C5F34C52232D14B00D57BEA /* FunctionalTableData+UITableViewDelegate.swift in Sources */,
 				4C63250C1F8AA89D00B2B74B /* TableItemConfigType.swift in Sources */,
 				4C7A27851F2FB55D00360E9B /* TableSectionChangeSet.swift in Sources */,
 				4C6325141F8AA8A400B2B74B /* CollectionItemConfigType.swift in Sources */,

--- a/FunctionalTableData/CollectionView/FunctionalCollectionData+UICollectionViewDataSource.swift
+++ b/FunctionalTableData/CollectionView/FunctionalCollectionData+UICollectionViewDataSource.swift
@@ -1,0 +1,51 @@
+//
+//  FunctionalCollectionData+UICollectionViewDataSource.swift
+//  FunctionalTableData
+//
+//  Created by Geoffrey Foster on 2019-03-08.
+//  Copyright © 2019 Shopify. All rights reserved.
+//
+
+import Foundation
+
+extension FunctionalCollectionData {
+	class DataSource: NSObject, UICollectionViewDataSource {
+		var sections: [TableSection] = []
+		
+		public func numberOfSections(in collectionView: UICollectionView) -> Int {
+			return sections.count
+		}
+		
+		public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+			return sections[section].rows.count
+		}
+		
+		public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+			let sectionData = sections[indexPath.section]
+			let row = indexPath.item
+			let cellConfig = sectionData[row]
+			let cell = cellConfig.dequeueCell(from: collectionView, at: indexPath)
+			
+			cellConfig.update(cell: cell, in: collectionView)
+			let style = cellConfig.style ?? CellStyle()
+			style.configure(cell: cell, in: collectionView)
+			
+			return cell
+		}
+		
+		public func collectionView(_ collectionView: UICollectionView, moveItemAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
+			// Should only ever be moving within section
+			assert(sourceIndexPath.section == destinationIndexPath.section)
+			
+			// Update internal state to match move
+			let cell = sections[sourceIndexPath.section].rows.remove(at: sourceIndexPath.item)
+			sections[destinationIndexPath.section].rows.insert(cell, at: destinationIndexPath.item)
+			
+			sections[sourceIndexPath.section].didMoveRow?(sourceIndexPath.item, destinationIndexPath.item)
+		}
+		
+		public func collectionView(_ collectionView: UICollectionView, canMoveItemAt indexPath: IndexPath) -> Bool {
+			return sections[indexPath]?.actions.canBeMoved ?? false
+		}
+	}
+}

--- a/FunctionalTableData/CollectionView/FunctionalCollectionData+UICollectionViewDelegate.swift
+++ b/FunctionalTableData/CollectionView/FunctionalCollectionData+UICollectionViewDelegate.swift
@@ -1,0 +1,105 @@
+//
+//  FunctionalCollectionData+UICollectionViewDelegate.swift
+//  FunctionalTableData
+//
+//  Created by Geoffrey Foster on 2019-03-08.
+//  Copyright © 2019 Shopify. All rights reserved.
+//
+
+import Foundation
+
+extension FunctionalCollectionData {
+	class Delegate: NSObject, UICollectionViewDelegate {
+		var sections: [TableSection] = []
+		
+		weak var scrollViewDelegate: UIScrollViewDelegate?
+		var backwardsCompatScrollViewDelegate = ScrollViewDelegate()
+		
+		public override func responds(to aSelector: Selector!) -> Bool {
+			if class_respondsToSelector(type(of: self), aSelector) {
+				return true
+			} else if let scrollViewDelegate = scrollViewDelegate, scrollViewDelegate.responds(to: aSelector) {
+				return true
+			} else if backwardsCompatScrollViewDelegate.responds(to: aSelector) {
+				return true
+			}
+			return super.responds(to: aSelector)
+		}
+		
+		public override func forwardingTarget(for aSelector: Selector!) -> Any? {
+			if class_respondsToSelector(type(of: self), aSelector) {
+				return self
+			} else if let scrollViewDelegate = scrollViewDelegate, scrollViewDelegate.responds(to: aSelector) {
+				return scrollViewDelegate
+			} else if backwardsCompatScrollViewDelegate.responds(to: aSelector) {
+				return backwardsCompatScrollViewDelegate
+			}
+			return super.forwardingTarget(for: aSelector)
+		}
+		
+		public func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
+			guard let indexPathsForSelectedItems = collectionView.indexPathsForSelectedItems, !collectionView.allowsMultipleSelection else { return true }
+			return indexPathsForSelectedItems.contains(indexPath) == false
+		}
+		
+		public func collectionView(_ collectionView: UICollectionView, shouldHighlightItemAt indexPath: IndexPath) -> Bool {
+			return sections[indexPath]?.actions.selectionAction != nil
+		}
+		
+		public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+			guard let cell = collectionView.cellForItem(at: indexPath) else { return }
+			let cellConfig = sections[indexPath]
+			
+			let selectionState = cellConfig?.actions.selectionAction?(cell) ?? .deselected
+			if selectionState == .deselected {
+				DispatchQueue.main.async {
+					collectionView.deselectItem(at: indexPath, animated: true)
+				}
+			}
+		}
+		
+		public func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
+			guard let cell = collectionView.cellForItem(at: indexPath) else { return }
+			let cellConfig = sections[indexPath]
+			
+			let selectionState = cellConfig?.actions.deselectionAction?(cell) ?? .deselected
+			if selectionState == .selected {
+				DispatchQueue.main.async {
+					collectionView.selectItem(at: indexPath, animated: true, scrollPosition: [])
+				}
+			}
+		}
+		
+		public func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+			guard indexPath.section < sections.count else { return }
+			
+			if let cellConfig = sections[indexPath] {
+				cellConfig.actions.visibilityAction?(cell, true)
+				return
+			}
+		}
+		
+		public func collectionView(_ collectionView: UICollectionView, didEndDisplaying cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+			if let cellConfig = sections[indexPath] {
+				cellConfig.actions.visibilityAction?(cell, false)
+				return
+			}
+		}
+		
+		public func collectionView(_ collectionView: UICollectionView, shouldShowMenuForItemAt indexPath: IndexPath) -> Bool {
+			return sections[indexPath]?.actions.canPerformAction != nil
+		}
+		
+		public func collectionView(_ collectionView: UICollectionView, canPerformAction action: Selector, forItemAt indexPath: IndexPath, withSender sender: Any?) -> Bool {
+			return sections[indexPath]?.actions.canPerformAction?(action) ?? false
+		}
+		
+		public func collectionView(_ collectionView: UICollectionView, performAction action: Selector, forItemAt indexPath: IndexPath, withSender sender: Any?) {
+			// required
+		}
+		
+		public func collectionView(_ collectionView: UICollectionView, targetIndexPathForMoveFromItemAt originalIndexPath: IndexPath, toProposedIndexPath proposedIndexPath: IndexPath) -> IndexPath {
+			return originalIndexPath.section == proposedIndexPath.section ? proposedIndexPath : originalIndexPath
+		}
+	}
+}

--- a/FunctionalTableData/ScrollViewDelegate.swift
+++ b/FunctionalTableData/ScrollViewDelegate.swift
@@ -86,91 +86,91 @@ public extension FunctionalTableData {
 	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619392-scrollviewdidscroll) for more information.
 	public var scrollViewDidScroll: ((_ scrollView: UIScrollView) -> Void)? {
 		get {
-			return backwardsCompatScrollViewDelegate.scrollViewDidScroll
+			return delegate.backwardsCompatScrollViewDelegate.scrollViewDidScroll
 		}
 		set {
-			backwardsCompatScrollViewDelegate.scrollViewDidScroll = newValue
+			delegate.backwardsCompatScrollViewDelegate.scrollViewDidScroll = newValue
 		}
 	}
 	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619394-scrollviewwillbegindragging) for more information.
 	public var scrollViewWillBeginDragging: ((_ scrollView: UIScrollView) -> Void)? {
 		get {
-			return backwardsCompatScrollViewDelegate.scrollViewWillBeginDragging
+			return delegate.backwardsCompatScrollViewDelegate.scrollViewWillBeginDragging
 		}
 		set {
-			backwardsCompatScrollViewDelegate.scrollViewWillBeginDragging = newValue
+			delegate.backwardsCompatScrollViewDelegate.scrollViewWillBeginDragging = newValue
 		}
 	}
 	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619385-scrollviewwillenddragging) for more information.
 	public var scrollViewWillEndDragging: ((_ scrollView: UIScrollView, _ velocity: CGPoint, _ targetContentOffset: UnsafeMutablePointer<CGPoint>) -> Void)? {
 		get {
-			return backwardsCompatScrollViewDelegate.scrollViewWillEndDragging
+			return delegate.backwardsCompatScrollViewDelegate.scrollViewWillEndDragging
 		}
 		set {
-			backwardsCompatScrollViewDelegate.scrollViewWillEndDragging = newValue
+			delegate.backwardsCompatScrollViewDelegate.scrollViewWillEndDragging = newValue
 		}
 	}
 	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619436-scrollviewdidenddragging) for more information.
 	public var scrollViewDidEndDragging: ((_ scrollView: UIScrollView, _ decelerate: Bool) -> Void)? {
 		get {
-			return backwardsCompatScrollViewDelegate.scrollViewDidEndDragging
+			return delegate.backwardsCompatScrollViewDelegate.scrollViewDidEndDragging
 		}
 		set {
-			backwardsCompatScrollViewDelegate.scrollViewDidEndDragging = newValue
+			delegate.backwardsCompatScrollViewDelegate.scrollViewDidEndDragging = newValue
 		}
 	}
 	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619386-scrollviewwillbegindecelerating) for more information.
 	public var scrollViewWillBeginDecelerating: ((_ scrollView: UIScrollView) -> Void)? {
 		get {
-			return backwardsCompatScrollViewDelegate.scrollViewWillBeginDecelerating
+			return delegate.backwardsCompatScrollViewDelegate.scrollViewWillBeginDecelerating
 		}
 		set {
-			backwardsCompatScrollViewDelegate.scrollViewWillBeginDecelerating = newValue
+			delegate.backwardsCompatScrollViewDelegate.scrollViewWillBeginDecelerating = newValue
 		}
 	}
 	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619417-scrollviewdidenddecelerating) for more information.
 	public var scrollViewDidEndDecelerating: ((_ scrollView: UIScrollView) -> Void)? {
 		get {
-			return backwardsCompatScrollViewDelegate.scrollViewDidEndDecelerating
+			return delegate.backwardsCompatScrollViewDelegate.scrollViewDidEndDecelerating
 		}
 		set {
-			backwardsCompatScrollViewDelegate.scrollViewDidEndDecelerating = newValue
+			delegate.backwardsCompatScrollViewDelegate.scrollViewDidEndDecelerating = newValue
 		}
 	}
 	/// Tells the delegate that the scroll view has changed its content size.
 	public var scrollViewDidChangeContentSize: ((_ scrollView: UIScrollView) -> Void)? {
 		get {
-			return backwardsCompatScrollViewDelegate.scrollViewDidChangeContentSize
+			return delegate.backwardsCompatScrollViewDelegate.scrollViewDidChangeContentSize
 		}
 		set {
-			backwardsCompatScrollViewDelegate.scrollViewDidChangeContentSize = newValue
+			delegate.backwardsCompatScrollViewDelegate.scrollViewDidChangeContentSize = newValue
 		}
 	}
 	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619379-scrollviewdidendscrollinganimati) for more information.
 	public var scrollViewDidEndScrollingAnimation: ((_ scrollView: UIScrollView) -> Void)? {
 		get {
-			return backwardsCompatScrollViewDelegate.scrollViewDidEndScrollingAnimation
+			return delegate.backwardsCompatScrollViewDelegate.scrollViewDidEndScrollingAnimation
 		}
 		set {
-			backwardsCompatScrollViewDelegate.scrollViewDidEndScrollingAnimation = newValue
+			delegate.backwardsCompatScrollViewDelegate.scrollViewDidEndScrollingAnimation = newValue
 		}
 	}
 	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619378-scrollviewshouldscrolltotop) for more information.
 	public var scrollViewShouldScrollToTop: ((_ scrollView: UIScrollView) -> Bool)? {
 		get {
-			return backwardsCompatScrollViewDelegate.scrollViewShouldScrollToTop
+			return delegate.backwardsCompatScrollViewDelegate.scrollViewShouldScrollToTop
 		}
 		set {
-			backwardsCompatScrollViewDelegate.scrollViewShouldScrollToTop = newValue
+			delegate.backwardsCompatScrollViewDelegate.scrollViewShouldScrollToTop = newValue
 		}
 	}
 	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619382-scrollviewdidscrolltotop) for more information.
 	public var scrollViewDidScrollToTop: ((_ scrollView: UIScrollView) -> Void)? {
 		get {
-			return backwardsCompatScrollViewDelegate.scrollViewDidScrollToTop
+			return delegate.backwardsCompatScrollViewDelegate.scrollViewDidScrollToTop
 		}
 		set {
-			backwardsCompatScrollViewDelegate.scrollViewDidScrollToTop = newValue
+			delegate.backwardsCompatScrollViewDelegate.scrollViewDidScrollToTop = newValue
 		}
 	}
 	
@@ -178,10 +178,10 @@ public extension FunctionalTableData {
 	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewaccessibilitydelegate/1621055-accessibilityscrollstatus) for more information.
 	public var scrollViewAccessibilityScrollStatus: ((_ scrollView: UIScrollView) -> String?)? {
 		get {
-			return backwardsCompatScrollViewDelegate.scrollViewAccessibilityScrollStatus
+			return delegate.backwardsCompatScrollViewDelegate.scrollViewAccessibilityScrollStatus
 		}
 		set {
-			backwardsCompatScrollViewDelegate.scrollViewAccessibilityScrollStatus = newValue
+			delegate.backwardsCompatScrollViewDelegate.scrollViewAccessibilityScrollStatus = newValue
 		}
 	}
 }
@@ -190,91 +190,91 @@ public extension FunctionalCollectionData {
 	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619392-scrollviewdidscroll) for more information.
 	public var scrollViewDidScroll: ((_ scrollView: UIScrollView) -> Void)? {
 		get {
-			return backwardsCompatScrollViewDelegate.scrollViewDidScroll
+			return delegate.backwardsCompatScrollViewDelegate.scrollViewDidScroll
 		}
 		set {
-			backwardsCompatScrollViewDelegate.scrollViewDidScroll = newValue
+			delegate.backwardsCompatScrollViewDelegate.scrollViewDidScroll = newValue
 		}
 	}
 	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619394-scrollviewwillbegindragging) for more information.
 	public var scrollViewWillBeginDragging: ((_ scrollView: UIScrollView) -> Void)? {
 		get {
-			return backwardsCompatScrollViewDelegate.scrollViewWillBeginDragging
+			return delegate.backwardsCompatScrollViewDelegate.scrollViewWillBeginDragging
 		}
 		set {
-			backwardsCompatScrollViewDelegate.scrollViewWillBeginDragging = newValue
+			delegate.backwardsCompatScrollViewDelegate.scrollViewWillBeginDragging = newValue
 		}
 	}
 	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619385-scrollviewwillenddragging) for more information.
 	public var scrollViewWillEndDragging: ((_ scrollView: UIScrollView, _ velocity: CGPoint, _ targetContentOffset: UnsafeMutablePointer<CGPoint>) -> Void)? {
 		get {
-			return backwardsCompatScrollViewDelegate.scrollViewWillEndDragging
+			return delegate.backwardsCompatScrollViewDelegate.scrollViewWillEndDragging
 		}
 		set {
-			backwardsCompatScrollViewDelegate.scrollViewWillEndDragging = newValue
+			delegate.backwardsCompatScrollViewDelegate.scrollViewWillEndDragging = newValue
 		}
 	}
 	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619436-scrollviewdidenddragging) for more information.
 	public var scrollViewDidEndDragging: ((_ scrollView: UIScrollView, _ decelerate: Bool) -> Void)? {
 		get {
-			return backwardsCompatScrollViewDelegate.scrollViewDidEndDragging
+			return delegate.backwardsCompatScrollViewDelegate.scrollViewDidEndDragging
 		}
 		set {
-			backwardsCompatScrollViewDelegate.scrollViewDidEndDragging = newValue
+			delegate.backwardsCompatScrollViewDelegate.scrollViewDidEndDragging = newValue
 		}
 	}
 	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619386-scrollviewwillbegindecelerating) for more information.
 	public var scrollViewWillBeginDecelerating: ((_ scrollView: UIScrollView) -> Void)? {
 		get {
-			return backwardsCompatScrollViewDelegate.scrollViewWillBeginDecelerating
+			return delegate.backwardsCompatScrollViewDelegate.scrollViewWillBeginDecelerating
 		}
 		set {
-			backwardsCompatScrollViewDelegate.scrollViewWillBeginDecelerating = newValue
+			delegate.backwardsCompatScrollViewDelegate.scrollViewWillBeginDecelerating = newValue
 		}
 	}
 	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619417-scrollviewdidenddecelerating) for more information.
 	public var scrollViewDidEndDecelerating: ((_ scrollView: UIScrollView) -> Void)? {
 		get {
-			return backwardsCompatScrollViewDelegate.scrollViewDidEndDecelerating
+			return delegate.backwardsCompatScrollViewDelegate.scrollViewDidEndDecelerating
 		}
 		set {
-			backwardsCompatScrollViewDelegate.scrollViewDidEndDecelerating = newValue
+			delegate.backwardsCompatScrollViewDelegate.scrollViewDidEndDecelerating = newValue
 		}
 	}
 	/// Tells the delegate that the scroll view has changed its content size.
 	public var scrollViewDidChangeContentSize: ((_ scrollView: UIScrollView) -> Void)? {
 		get {
-			return backwardsCompatScrollViewDelegate.scrollViewDidChangeContentSize
+			return delegate.backwardsCompatScrollViewDelegate.scrollViewDidChangeContentSize
 		}
 		set {
-			backwardsCompatScrollViewDelegate.scrollViewDidChangeContentSize = newValue
+			delegate.backwardsCompatScrollViewDelegate.scrollViewDidChangeContentSize = newValue
 		}
 	}
 	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619379-scrollviewdidendscrollinganimati) for more information.
 	public var scrollViewDidEndScrollingAnimation: ((_ scrollView: UIScrollView) -> Void)? {
 		get {
-			return backwardsCompatScrollViewDelegate.scrollViewDidEndScrollingAnimation
+			return delegate.backwardsCompatScrollViewDelegate.scrollViewDidEndScrollingAnimation
 		}
 		set {
-			backwardsCompatScrollViewDelegate.scrollViewDidEndScrollingAnimation = newValue
+			delegate.backwardsCompatScrollViewDelegate.scrollViewDidEndScrollingAnimation = newValue
 		}
 	}
 	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619378-scrollviewshouldscrolltotop) for more information.
 	public var scrollViewShouldScrollToTop: ((_ scrollView: UIScrollView) -> Bool)? {
 		get {
-			return backwardsCompatScrollViewDelegate.scrollViewShouldScrollToTop
+			return delegate.backwardsCompatScrollViewDelegate.scrollViewShouldScrollToTop
 		}
 		set {
-			backwardsCompatScrollViewDelegate.scrollViewShouldScrollToTop = newValue
+			delegate.backwardsCompatScrollViewDelegate.scrollViewShouldScrollToTop = newValue
 		}
 	}
 	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619382-scrollviewdidscrolltotop) for more information.
 	public var scrollViewDidScrollToTop: ((_ scrollView: UIScrollView) -> Void)? {
 		get {
-			return backwardsCompatScrollViewDelegate.scrollViewDidScrollToTop
+			return delegate.backwardsCompatScrollViewDelegate.scrollViewDidScrollToTop
 		}
 		set {
-			backwardsCompatScrollViewDelegate.scrollViewDidScrollToTop = newValue
+			delegate.backwardsCompatScrollViewDelegate.scrollViewDidScrollToTop = newValue
 		}
 	}
 	
@@ -282,10 +282,10 @@ public extension FunctionalCollectionData {
 	/// See UIScrollView's [documentation](https://developer.apple.com/documentation/uikit/uiscrollviewaccessibilitydelegate/1621055-accessibilityscrollstatus) for more information.
 	public var scrollViewAccessibilityScrollStatus: ((_ scrollView: UIScrollView) -> String?)? {
 		get {
-			return backwardsCompatScrollViewDelegate.scrollViewAccessibilityScrollStatus
+			return delegate.backwardsCompatScrollViewDelegate.scrollViewAccessibilityScrollStatus
 		}
 		set {
-			backwardsCompatScrollViewDelegate.scrollViewAccessibilityScrollStatus = newValue
+			delegate.backwardsCompatScrollViewDelegate.scrollViewAccessibilityScrollStatus = newValue
 		}
 	}
 }

--- a/FunctionalTableData/TableView/FunctionalTableData+UITableViewDataSource.swift
+++ b/FunctionalTableData/TableView/FunctionalTableData+UITableViewDataSource.swift
@@ -1,0 +1,57 @@
+//
+//  FunctionalTableData+UITableViewDataSource.swift
+//  FunctionalTableData
+//
+//  Created by Geoffrey Foster on 2019-03-08.
+//  Copyright © 2019 Shopify. All rights reserved.
+//
+
+import Foundation
+
+extension FunctionalTableData {
+	class DataSource: NSObject, UITableViewDataSource {
+		var sections: [TableSection] = []
+		
+		public func numberOfSections(in tableView: UITableView) -> Int {
+			return sections.count
+		}
+		
+		public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+			return sections[section].rows.count
+		}
+		
+		public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+			let sectionData = sections[indexPath.section]
+			let row = indexPath.row
+			let cellConfig = sectionData[row]
+			let cell = cellConfig.dequeueCell(from: tableView, at: indexPath)
+			cell.accessibilityIdentifier = sectionData.sectionKeyPathForRow(row)
+			
+			cellConfig.update(cell: cell, in: tableView)
+			let style = sectionData.mergedStyle(for: row)
+			style.configure(cell: cell, in: tableView)
+			
+			return cell
+		}
+		
+		public func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
+			// Should only ever be moving within section
+			assert(sourceIndexPath.section == destinationIndexPath.section)
+			
+			// Update internal state to match move
+			let cell = sections[sourceIndexPath.section].rows.remove(at: sourceIndexPath.row)
+			sections[destinationIndexPath.section].rows.insert(cell, at: destinationIndexPath.row)
+			
+			sections[sourceIndexPath.section].didMoveRow?(sourceIndexPath.row, destinationIndexPath.row)
+		}
+		
+		public func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
+			return sections[indexPath]?.actions.canBeMoved ?? false
+		}
+		
+		public func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+			let cellConfig = sections[indexPath]
+			return cellConfig?.actions.rowActions != nil || self.tableView(tableView, canMoveRowAt: indexPath)
+		}
+	}
+}

--- a/FunctionalTableData/TableView/FunctionalTableData+UITableViewDelegate.swift
+++ b/FunctionalTableData/TableView/FunctionalTableData+UITableViewDelegate.swift
@@ -1,0 +1,211 @@
+//
+//  FunctionalTableData+UITableViewDelegate.swift
+//  FunctionalTableData
+//
+//  Created by Geoffrey Foster on 2019-03-08.
+//  Copyright © 2019 Shopify. All rights reserved.
+//
+
+import Foundation
+
+extension FunctionalTableData {
+	class Delegate: NSObject, UITableViewDelegate {
+		var sections: [TableSection] = []
+		private var heightAtIndexKeyPath: [String: CGFloat] = [:]
+		
+		weak var scrollViewDelegate: UIScrollViewDelegate?
+		var backwardsCompatScrollViewDelegate = ScrollViewDelegate()
+		
+		public override func responds(to aSelector: Selector!) -> Bool {
+			if class_respondsToSelector(type(of: self), aSelector) {
+				return true
+			} else if let scrollViewDelegate = scrollViewDelegate, scrollViewDelegate.responds(to: aSelector) {
+				return true
+			} else if backwardsCompatScrollViewDelegate.responds(to: aSelector) {
+				return true
+			}
+			return super.responds(to: aSelector)
+		}
+		
+		public override func forwardingTarget(for aSelector: Selector!) -> Any? {
+			if class_respondsToSelector(type(of: self), aSelector) {
+				return self
+			} else if let scrollViewDelegate = scrollViewDelegate, scrollViewDelegate.responds(to: aSelector) {
+				return scrollViewDelegate
+			} else if backwardsCompatScrollViewDelegate.responds(to: aSelector) {
+				return backwardsCompatScrollViewDelegate
+			}
+			return super.forwardingTarget(for: aSelector)
+		}
+		
+		public func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+			guard let header = sections[section].header else {
+				// When given a height of zero grouped style UITableView's use their default value instead of zero. By returning CGFloat.min we get around this behavior and force UITableView to end up using a height of zero after all.
+				return tableView.style == .grouped ? CGFloat.leastNormalMagnitude : 0
+			}
+			return header.height
+		}
+		
+		public func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+			guard let footer = sections[section].footer else {
+				// When given a height of zero grouped style UITableView's use their default value instead of zero. By returning CGFloat.min we get around this behavior and force UITableView to end up using a height of zero after all.
+				return tableView.style == .grouped ? CGFloat.leastNormalMagnitude : 0
+			}
+			return footer.height
+		}
+		
+		public func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
+			guard indexPath.section < sections.count else { return UITableView.automaticDimension }
+			if let indexKeyPath = sections[indexPath.section].sectionKeyPathForRow(indexPath.row), let height = heightAtIndexKeyPath[indexKeyPath] {
+				return height
+			} else {
+				return UITableView.automaticDimension
+			}
+		}
+		
+		public func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+			guard let header = sections[section].header else { return nil }
+			return header.dequeueHeaderFooter(from: tableView)
+		}
+		
+		public func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+			guard let footer = sections[section].footer else { return nil }
+			return footer.dequeueHeaderFooter(from: tableView)
+		}
+		
+		public func tableView(_ tableView: UITableView, shouldHighlightRowAt indexPath: IndexPath) -> Bool {
+			let cellConfig = sections[indexPath]
+			return cellConfig?.actions.selectionAction != nil
+		}
+		
+		public func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
+			if tableView.indexPathForSelectedRow == indexPath {
+				return nil
+			}
+			
+			guard let cellConfig = sections[indexPath], let selectionAction = cellConfig.actions.selectionAction else {
+				return nil
+			}
+			
+			let currentSelection = tableView.indexPathForSelectedRow
+			
+			if let canSelectAction = cellConfig.actions.canSelectAction, let selectedCell = tableView.cellForRow(at: indexPath) {
+				let canSelectResult: (Bool) -> Void = { selected in
+					if #available(iOSApplicationExtension 10.0, *) {
+						dispatchPrecondition(condition: .onQueue(DispatchQueue.main))
+					}
+					if selected {
+						selectedCell.setHighlighted(false, animated: false)
+						
+						if selectionAction(selectedCell) == .selected {
+							tableView.selectRow(at: indexPath, animated: false, scrollPosition: .none)
+						} else {
+							tableView.deselectRow(at: indexPath, animated: false)
+						}
+						
+						if !tableView.allowsMultipleSelection, let currentSelection = currentSelection {
+							tableView.cellForRow(at: currentSelection)?.setHighlighted(false, animated: false)
+							tableView.deselectRow(at: currentSelection, animated: false)
+						}
+					} else {
+						selectedCell.setHighlighted(false, animated: true)
+					}
+				}
+				DispatchQueue.main.async {
+					selectedCell.setHighlighted(true, animated: false)
+					canSelectAction(canSelectResult)
+				}
+				return nil
+			} else {
+				return indexPath
+			}
+		}
+		
+		public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+			guard let cell = tableView.cellForRow(at: indexPath) else { return }
+			let cellConfig = sections[indexPath]
+			
+			let selectionState = cellConfig?.actions.selectionAction?(cell) ?? .deselected
+			if selectionState == .deselected {
+				DispatchQueue.main.async {
+					tableView.deselectRow(at: indexPath, animated: true)
+				}
+			}
+		}
+		
+		public func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {
+			guard let cell = tableView.cellForRow(at: indexPath) else { return }
+			let cellConfig = sections[indexPath]
+			
+			let selectionState = cellConfig?.actions.deselectionAction?(cell) ?? .deselected
+			if selectionState == .selected {
+				DispatchQueue.main.async {
+					tableView.selectRow(at: indexPath, animated: true, scrollPosition: .none)
+				}
+			}
+		}
+		
+		public func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+			guard indexPath.section < sections.count else { return }
+			
+			if let indexKeyPath = sections[indexPath.section].sectionKeyPathForRow(indexPath.row) {
+				heightAtIndexKeyPath[indexKeyPath] = cell.bounds.height
+			}
+			
+			if let cellConfig = sections[indexPath] {
+				cellConfig.actions.visibilityAction?(cell, true)
+				return
+			}
+		}
+		
+		public func tableView(_ tableView: UITableView, didEndDisplaying cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+			if let cellConfig = sections[indexPath] {
+				cellConfig.actions.visibilityAction?(cell, false)
+				return
+			}
+		}
+		
+		public func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
+			let tableSection = sections[section]
+			tableSection.headerVisibilityAction?(view, true)
+		}
+		
+		public func tableView(_ tableView: UITableView, didEndDisplayingHeaderView view: UIView, forSection section: Int) {
+			guard section < sections.count else { return }
+			let tableSection = sections[section]
+			tableSection.headerVisibilityAction?(view, false)
+		}
+		
+		public func tableView(_ tableView: UITableView, shouldShowMenuForRowAt indexPath: IndexPath) -> Bool {
+			let cellConfig = sections[indexPath]
+			return cellConfig?.actions.canPerformAction != nil
+		}
+		
+		public func tableView(_ tableView: UITableView, canPerformAction action: Selector, forRowAt indexPath: IndexPath, withSender sender: Any?) -> Bool {
+			let cellConfig = sections[indexPath]
+			return cellConfig?.actions.canPerformAction?(action) ?? false
+		}
+		
+		public func tableView(_ tableView: UITableView, performAction action: Selector, forRowAt indexPath: IndexPath, withSender sender: Any?) {
+			// required
+		}
+		
+		public func tableView(_ tableView: UITableView, editingStyleForRowAt indexPath: IndexPath) -> UITableViewCell.EditingStyle {
+			let cellConfig = sections[indexPath]
+			return cellConfig?.actions.rowActions != nil ? .delete : .none
+		}
+		
+		public func tableView(_ tableView: UITableView, shouldIndentWhileEditingRowAt indexPath: IndexPath) -> Bool {
+			return false
+		}
+		
+		public func tableView(_ tableView: UITableView, targetIndexPathForMoveFromRowAt sourceIndexPath: IndexPath, toProposedIndexPath proposedDestinationIndexPath: IndexPath) -> IndexPath {
+			return sourceIndexPath.section == proposedDestinationIndexPath.section ? proposedDestinationIndexPath : sourceIndexPath
+		}
+		
+		public func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
+			let cellConfig = sections[indexPath]
+			return cellConfig?.actions.rowActions
+		}
+	}
+}


### PR DESCRIPTION
Separates the UICollectionView and UITableView Delegate/DataSource objects into their own objects. This removes the need for FunctionalTableData to extend NSObject, isolates the logic/code associated with the protocols.