### PR TITLE
adding the ItemPath type to replace KeyPath

### DIFF
--- a/FunctionalTableData.xcodeproj/project.pbxproj
+++ b/FunctionalTableData.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		4CA356761F322D7F0081BE90 /* TableSectionStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA356741F322D7F0081BE90 /* TableSectionStyleTests.swift */; };
 		4CCCE8481F8AA7F400C73258 /* TableItemLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CCCE8471F8AA7F400C73258 /* TableItemLayout.swift */; };
 		4CD535031F9E3A010041A3F9 /* CellStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CD535021F9E3A010041A3F9 /* CellStyleTests.swift */; };
+		6C421788224D42C500D64AE2 /* ItemPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C421787224D42C500D64AE2 /* ItemPath.swift */; };
 		6C5F34C12231B91C00D57BEA /* ScrollViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C5F34C02231B91C00D57BEA /* ScrollViewDelegate.swift */; };
 		6C5F34C52232D14B00D57BEA /* FunctionalTableData+UITableViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C5F34C42232D14B00D57BEA /* FunctionalTableData+UITableViewDelegate.swift */; };
 		6C5F34C72232D15500D57BEA /* FunctionalTableData+UITableViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C5F34C62232D15500D57BEA /* FunctionalTableData+UITableViewDataSource.swift */; };
@@ -127,6 +128,7 @@
 		4CCCE8461F8AA7CD00C73258 /* UITableView+Reusable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+Reusable.swift"; sourceTree = "<group>"; };
 		4CCCE8471F8AA7F400C73258 /* TableItemLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableItemLayout.swift; sourceTree = "<group>"; };
 		4CD535021F9E3A010041A3F9 /* CellStyleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellStyleTests.swift; sourceTree = "<group>"; };
+		6C421787224D42C500D64AE2 /* ItemPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemPath.swift; sourceTree = "<group>"; };
 		6C5F34C02231B91C00D57BEA /* ScrollViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollViewDelegate.swift; sourceTree = "<group>"; };
 		6C5F34C42232D14B00D57BEA /* FunctionalTableData+UITableViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FunctionalTableData+UITableViewDelegate.swift"; sourceTree = "<group>"; };
 		6C5F34C62232D15500D57BEA /* FunctionalTableData+UITableViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FunctionalTableData+UITableViewDataSource.swift"; sourceTree = "<group>"; };
@@ -238,6 +240,7 @@
 				4CCCE83E1F8AA7B200C73258 /* CollectionView */,
 				4C7A27871F2FB68400360E9B /* Extensions */,
 				4CCCE8431F8AA7CD00C73258 /* TableView */,
+				6C421787224D42C500D64AE2 /* ItemPath.swift */,
 			);
 			name = Source;
 			sourceTree = "<group>";
@@ -406,6 +409,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -484,6 +488,7 @@
 				6C5F34C92232E8D300D57BEA /* FunctionalCollectionData+UICollectionViewDelegate.swift in Sources */,
 				4C6325111F8AA8A400B2B74B /* CollectionCell.swift in Sources */,
 				4C7A27841F2FB55D00360E9B /* TableSection.swift in Sources */,
+				6C421788224D42C500D64AE2 /* ItemPath.swift in Sources */,
 				6C5F34C72232D15500D57BEA /* FunctionalTableData+UITableViewDataSource.swift in Sources */,
 				4C7A277D1F2FB55D00360E9B /* FunctionalTableData.swift in Sources */,
 				4C7A277E1F2FB55D00360E9B /* HostCell.swift in Sources */,

--- a/FunctionalTableData/HostCell.swift
+++ b/FunctionalTableData/HostCell.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-/// Defines the view, state and layout information of a row item inside a TableSection.
+/// Defines the view, state and layout information of an item inside a TableSection.
 /// It relies on you to build UIView subclasses and use those instead of implementing UITableViewCell or UICollectionViewCell subclasses. This has the side effect of building better more reusable view components. This greatly simplifies composition by combining several host-cells into more complex layouts. It also makes equality simpler and more "Swifty" by requiring that anything provided as State only requires that the State object conform to the Equatable protocol. The View portion of the generic only requires it to be a UIView subclass.
 public struct HostCell<View, State, Layout>: CellConfigType where View: UIView, State: Equatable, Layout: TableItemLayout {
 	public typealias TableViewCellType = TableCell<View, Layout>

--- a/FunctionalTableData/ItemPath.swift
+++ b/FunctionalTableData/ItemPath.swift
@@ -1,0 +1,41 @@
+//
+//  ItemPath.swift
+//  FunctionalTableData
+//
+//  Created by Geoffrey Foster on 2019-03-28.
+//  Copyright © 2019 Shopify. All rights reserved.
+//
+
+import Foundation
+
+/// Represents the unique path to a given item in the `FunctionalData`.
+///
+/// Think of it as a readable implementation of `IndexPath`, that can be used to locate a given cell
+/// or `TableSection` in the data set.
+public struct ItemPath: Hashable, CustomStringConvertible {
+	/// Unique identifier for a section.
+	public let sectionKey: String
+	/// Unique identifier for an item inside a section.
+	public let itemKey: String
+	
+	public init(sectionKey: String, itemKey: String) {
+		self.sectionKey = sectionKey
+		self.itemKey = itemKey
+	}
+	
+	public var description: String {
+		return "\(sectionKey).\(itemKey)"
+	}
+}
+
+// MARK: - Compatibility
+
+public extension ItemPath {
+	init(sectionKey: String, rowKey: String) {
+		self.init(sectionKey: sectionKey, itemKey: rowKey)
+	}
+
+	var rowKey: String {
+		return itemKey
+	}
+}

--- a/FunctionalTableData/TableSection.swift
+++ b/FunctionalTableData/TableSection.swift
@@ -16,7 +16,7 @@ public protocol TableSectionType {
 	var header: TableHeaderFooterConfigType? { get }
 	/// View object to display in the footer of this section.
 	var footer: TableHeaderFooterConfigType? { get }
-	/// Instances of `CellConfigType` that represent the rows in the table view.
+	/// Instances of `CellConfigType` that represent the items in the table.
 	var rows: [CellConfigType] { get }
 	/// Action to perform when the header view comes in or out of view.
 	var headerVisibilityAction: ((_ view: UIView, _ visible: Bool) -> Void)? { get }
@@ -28,16 +28,16 @@ public protocol TableSectionType {
 
 /// Defines the style, and state information of a section.
 ///
-/// `FunctionalTableData` deals in arrays of `TableSection` instances. Each section, at a minimum, has a string value unique within the table itself, and an array of `CellConfigType` instances that represent the rows of the section. Additionally there may be a header and footer for the section.
+/// `FunctionalTableData` deals in arrays of `TableSection` instances. Each section, at a minimum, has a string value unique within the table itself, and an array of `CellConfigType` instances that represent the items of the section. Additionally there may be a header and footer for the section.
 public struct TableSection: Sequence, TableSectionType {
 	public let key: String
 	public var header: TableHeaderFooterConfigType? = nil
 	public var footer: TableHeaderFooterConfigType? = nil
 	public var rows: [CellConfigType]
-	/// Specifies visual attributes to be applied to the section. This includes row separators to use at the top, bottom, and between items of the section.
+	/// Specifies visual attributes to be applied to the section. This includes item separators to use at the top, bottom, and between items of the section.
 	public var style: SectionStyle?
 	public var headerVisibilityAction: ((_ view: UIView, _ visible: Bool) -> Void)? = nil
-	/// Callback executed when a row is manually moved by the user. It specifies the before and after index position.
+	/// Callback executed when a item is manually moved by the user. It specifies the before and after index position.
 	public var didMoveRow: ((_ from: Int, _ to: Int) -> Void)?
 
 	public init(key: String, rows: [CellConfigType] = [], header: TableHeaderFooterConfigType? = nil, footer: TableHeaderFooterConfigType? = nil, style: SectionStyle? = nil, didMoveRow: ((_ from: Int, _ to: Int) -> Void)? = nil) {
@@ -81,9 +81,9 @@ public struct TableSection: Sequence, TableSectionType {
 	///
 	/// - Parameter index: Integer identifying the position of the row in the section.
 	/// - Returns: The String identifier of the section enclosing the row.
-	func sectionKeyPathForRow(_ index: Int) -> String? {
+	func sectionKeyPathForRow(_ index: Int) -> ItemPath? {
 		guard index < rows.count else { return nil }
-		return key + rows[index].key
+		return ItemPath(sectionKey: key, itemKey: rows[index].key)
 	}
 
 	/// Attempts to merge the separator's style provided by a `TableSection` with the separator's style provided by an instance of `CellConfigType`.
@@ -155,9 +155,9 @@ extension TableSection {
 
 extension Array where Element: TableSectionType {
 	subscript(key: IndexPath) -> CellConfigType? {
-		guard (key as NSIndexPath).section < count else { return nil }
-		let row = (key as NSIndexPath).row
-		let section: TableSectionType = self[(key as NSIndexPath).section]
+		guard key.section < count else { return nil }
+		let row = key.row
+		let section: TableSectionType = self[key.section]
 		return (row < section.rows.count) ? section[row] : nil
 	}
 }

--- a/FunctionalTableData/TableView/FunctionalTableData+UITableViewDataSource.swift
+++ b/FunctionalTableData/TableView/FunctionalTableData+UITableViewDataSource.swift
@@ -25,7 +25,7 @@ extension FunctionalTableData {
 			let row = indexPath.row
 			let cellConfig = sectionData[row]
 			let cell = cellConfig.dequeueCell(from: tableView, at: indexPath)
-			cell.accessibilityIdentifier = sectionData.sectionKeyPathForRow(row)
+			cell.accessibilityIdentifier = ItemPath(sectionKey: sectionData.key, itemKey: cellConfig.key).description
 			
 			cellConfig.update(cell: cell, in: tableView)
 			let style = sectionData.mergedStyle(for: row)

--- a/FunctionalTableData/TableView/FunctionalTableData+UITableViewDelegate.swift
+++ b/FunctionalTableData/TableView/FunctionalTableData+UITableViewDelegate.swift
@@ -11,7 +11,7 @@ import Foundation
 extension FunctionalTableData {
 	class Delegate: NSObject, UITableViewDelegate {
 		var sections: [TableSection] = []
-		private var heightAtIndexKeyPath: [String: CGFloat] = [:]
+		private var heightAtIndexKeyPath: [ItemPath: CGFloat] = [:]
 		
 		weak var scrollViewDelegate: UIScrollViewDelegate?
 		var backwardsCompatScrollViewDelegate = ScrollViewDelegate()


### PR DESCRIPTION
KeyPath is a built in Swift type, and having two different KeyPath (FunctionalTableData.KeyPath and FunctionalCollectionData.KeyPath) isn't necessary, so adding the ItemPath type that will be used by both