### PR TITLE
Adds support for UITableView leading/trailing row actions

### DIFF
--- a/FunctionalTableData.xcodeproj/project.pbxproj
+++ b/FunctionalTableData.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		6C5F34C72232D15500D57BEA /* FunctionalTableData+UITableViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C5F34C62232D15500D57BEA /* FunctionalTableData+UITableViewDataSource.swift */; };
 		6C5F34C92232E8D300D57BEA /* FunctionalCollectionData+UICollectionViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C5F34C82232E8D300D57BEA /* FunctionalCollectionData+UICollectionViewDelegate.swift */; };
 		6C5F34CB2232E99000D57BEA /* FunctionalCollectionData+UICollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C5F34CA2232E99000D57BEA /* FunctionalCollectionData+UICollectionViewDataSource.swift */; };
+		6C910BA922529B390000D7E9 /* FunctionalTableDataDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C910BA822529B390000D7E9 /* FunctionalTableDataDelegateTests.swift */; };
 		9FF97DB3212CA23B006FA047 /* TableCellReuseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FF97DB2212CA23B006FA047 /* TableCellReuseTests.swift */; };
 		BC8C5D4121763B7B00443E28 /* BackgroundViewProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC8C5D4021763B7B00443E28 /* BackgroundViewProvider.swift */; };
 /* End PBXBuildFile section */
@@ -134,6 +135,7 @@
 		6C5F34C62232D15500D57BEA /* FunctionalTableData+UITableViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FunctionalTableData+UITableViewDataSource.swift"; sourceTree = "<group>"; };
 		6C5F34C82232E8D300D57BEA /* FunctionalCollectionData+UICollectionViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FunctionalCollectionData+UICollectionViewDelegate.swift"; sourceTree = "<group>"; };
 		6C5F34CA2232E99000D57BEA /* FunctionalCollectionData+UICollectionViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FunctionalCollectionData+UICollectionViewDataSource.swift"; sourceTree = "<group>"; };
+		6C910BA822529B390000D7E9 /* FunctionalTableDataDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunctionalTableDataDelegateTests.swift; sourceTree = "<group>"; };
 		9FF97DB2212CA23B006FA047 /* TableCellReuseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableCellReuseTests.swift; sourceTree = "<group>"; };
 		BC8C5D4021763B7B00443E28 /* BackgroundViewProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundViewProvider.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -217,6 +219,7 @@
 				4CA356741F322D7F0081BE90 /* TableSectionStyleTests.swift */,
 				36C9208C20D3EB7500DA4251 /* TableSectionsValidationTests.swift */,
 				9FF97DB2212CA23B006FA047 /* TableCellReuseTests.swift */,
+				6C910BA822529B390000D7E9 /* FunctionalTableDataDelegateTests.swift */,
 			);
 			path = FunctionalTableDataTests;
 			sourceTree = "<group>";
@@ -510,6 +513,7 @@
 				4CD535031F9E3A010041A3F9 /* CellStyleTests.swift in Sources */,
 				36C9208D20D3EB7500DA4251 /* TableSectionsValidationTests.swift in Sources */,
 				9FF97DB3212CA23B006FA047 /* TableCellReuseTests.swift in Sources */,
+				6C910BA922529B390000D7E9 /* FunctionalTableDataDelegateTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/FunctionalTableData/CellActions.swift
+++ b/FunctionalTableData/CellActions.swift
@@ -9,8 +9,112 @@
 import Foundation
 import UIKit
 
-/// The actions property exposed on the CellConfigType represents possible events that will be executed based on the users interaction with that particular cell. Of note are the `selectionAction` and `previewingViewControllerAction`. The `selectionAction` is executed when the user taps on that particular cell. The main use case for this is present a new detail view controller or a modal (but is not constrained to these actions, these are just the common use cases). The `previewingViewControllerAction` is responsible for returning an instance of a UIViewController that will be shown when a user 3D-touches on a cell.
+/// The actions property exposed on the CellConfigType represents possible events that will be executed based on the users interaction with that particular cell.
 public struct CellActions {
+	/// Create a SwipeActionsConfiguration object to associate custom swipe actions with a row of your table view. Users swipe horizontally left or right in a table view to reveal the actions associated with a row. Each swipe-actions object contains the set of actions to display for each type of swipe.
+	public struct SwipeActionsConfiguration {
+		/// An action to display when the user swipes a table row.
+		///
+		/// Create UIContextualAction objects to define the types of actions that can be performed when the user swipes left or right on a table row.
+		public struct ContextualAction {
+			/// The handler block to call in response to the selection of an action
+			/// - Parameters:
+			///   - sourceView: The view in which the action was displayed.
+			///   - completionHandler: The handler block for you to execute after you have performed the action. This block has no return value and takes the following parameter:
+			///   - actionPerformed: A Boolean value indicating whether you performed the action. Specify true if you performed the action or false if you were unable to perform the action for some reason.
+			public typealias Handler = (_ sourceView: UIView, _ completionHandler: (_ actionPerformed: Bool) -> Void) -> Void
+			
+			/// Constants indicating the style information that is applied to the action button.
+			///
+			/// - normal: A normal action.
+			/// - destructive: An action that deletes data or performs some type of destructive task.
+			public enum Style {
+				case normal
+				case destructive
+			}
+			let title: String?
+			let backgroundColor: UIColor?
+			let image: UIImage?
+			let style: Style
+			let handler: Handler
+			
+			/// Creates a new contextual action.
+			///
+			/// - Parameters:
+			///   - title: The title of the action button.
+			///   - backgroundColor: The background color of the action button.
+			///   - image: The image to display in the action button.
+			///   - style: The style information to apply to the action button.
+			///   - handler: The handler to execute when the user selects the action.
+			public init(title: String?, backgroundColor: UIColor? = nil, image: UIImage? = nil, style: Style, handler: @escaping Handler) {
+				self.title = title
+				self.backgroundColor = backgroundColor
+				self.image = image
+				self.style = style
+				self.handler = handler
+			}
+			
+			internal func asRowAction(in tableView: UITableView) -> UITableViewRowAction {
+				let style: UITableViewRowAction.Style
+				switch self.style {
+				case .normal:
+					style = .normal
+				case .destructive:
+					style = .destructive
+				}
+				let rowAction = UITableViewRowAction(style: style, title: title) { [handler] (_, indexPath) in
+					let cell = tableView.cellForRow(at: indexPath)
+					handler(cell ?? tableView) { _ in } // UITableViewRowAction doesn't support the callback based approach, so fake it instead
+				}
+				rowAction.backgroundColor = backgroundColor
+				return rowAction
+			}
+			
+			@available(iOSApplicationExtension 11.0, *)
+			internal func asContextualAction() -> UIContextualAction {
+				let style: UIContextualAction.Style
+				switch self.style {
+				case .normal:
+					style = .normal
+				case .destructive:
+					style = .destructive
+				}
+				let contextualAction = UIContextualAction(style: style, title: title, handler: { [handler] (_, sourceView, completionHandler) in
+					handler(sourceView, completionHandler)
+				})
+				contextualAction.image = image
+				if let backgroundColor = backgroundColor {
+					contextualAction.backgroundColor = backgroundColor
+				}
+				
+				return contextualAction
+			}
+		}
+		
+		let actions: [ContextualAction]
+		let performsFirstActionWithFullSwipe: Bool
+
+		/// Creates a swipe action configuration object with the specified set of actions.
+		///
+		/// - Parameters:
+		///   - actions: The swipe actions.
+		///   - performsFirstActionWithFullSwipe: Whether a full swipe automatically performs the first action. Defaults to `true`.
+		public init(actions: [ContextualAction], performsFirstActionWithFullSwipe: Bool = true) {
+			self.actions = actions
+			self.performsFirstActionWithFullSwipe = performsFirstActionWithFullSwipe
+		}
+		
+		func asRowActions(in tableView: UITableView) -> [UITableViewRowAction] {
+			return actions.map { $0.asRowAction(in: tableView) }
+		}
+		
+		@available(iOSApplicationExtension 11.0, *)
+		func asSwipeActionsConfiguration() -> UISwipeActionsConfiguration {
+			let configuration = UISwipeActionsConfiguration(actions: actions.map { $0.asContextualAction() })
+			configuration.performsFirstActionWithFullSwipe = performsFirstActionWithFullSwipe
+			return configuration
+		}
+	}
 	/// The possible states a cell can be when a selection action is performed on it.
 	public enum SelectionState {
 		case selected
@@ -36,8 +140,21 @@ public struct CellActions {
 	public let selectionAction: SelectionAction?
 	/// The action to perform when the cell is deselected
 	public let deselectionAction: SelectionAction?
+	
 	/// All the available row actions this cell can perform. See [UITableViewRowAction](https://developer.apple.com/documentation/uikit/uitableviewrowaction) for more info.
+	//@available(*, deprecated, message: "Use `trailingActionConfiguration` instead.")
 	public let rowActions: [UITableViewRowAction]?
+	
+	/// The swipe actions to display on the leading edge of the row.
+	///
+	/// Use this method to return a set of actions to display when the user swipes the row. The actions you return are displayed on the leading edge of the row. For example, in a left-to-right language environment, they are displayed on the left side of the row when the user swipes from left to right.
+	public let leadingActionConfiguration: SwipeActionsConfiguration?
+	
+	/// The swipe actions to display next to the trailing edge of the row. Return nil if you want the table to display the default set of actions.
+	///
+	/// Use this method to return a set of actions to display when the user swipes the row. The actions you return are displayed on the trailing edge of the row. For example, in a left-to-right language environment, they are displayed on the right side of the row when the user swipes from right to left.
+	public let trailingActionConfiguration: SwipeActionsConfiguration?
+	
 	/// Indicates if the cell can perform a given action.
 	public let canPerformAction: CanPerformAction?
 	/// Indicates if the cell can be manually moved by the user.
@@ -47,36 +164,80 @@ public struct CellActions {
 	/// The action to perform when the cell is 3D touched by the user.
 	public let previewingViewControllerAction: PreviewingViewControllerAction?
 	
-	public init(canSelectAction: CanSelectAction? = nil,
-				selectionAction: SelectionAction? = nil,
-				deselectionAction: DeselectionAction? = nil,
-				rowActions: [UITableViewRowAction]? = nil,
-				canPerformAction: CanPerformAction? = nil,
-				canBeMoved: Bool = false,
-				visibilityAction: VisibilityAction? = nil,
-				previewingViewControllerAction: PreviewingViewControllerAction? = nil) {
+	public init(
+		canSelectAction: CanSelectAction? = nil,
+		selectionAction: SelectionAction? = nil,
+		deselectionAction: DeselectionAction? = nil,
+		leadingActionConfiguration: SwipeActionsConfiguration? = nil,
+		trailingActionConfiguration: SwipeActionsConfiguration? = nil,
+		canPerformAction: CanPerformAction? = nil,
+		canBeMoved: Bool = false,
+		visibilityAction: VisibilityAction? = nil,
+		previewingViewControllerAction: PreviewingViewControllerAction? = nil) {
 		self.canSelectAction = canSelectAction
 		self.selectionAction = selectionAction
 		self.deselectionAction = deselectionAction
-		self.rowActions = rowActions
+		self.rowActions = nil
+		self.leadingActionConfiguration = leadingActionConfiguration
+		self.trailingActionConfiguration = trailingActionConfiguration
 		self.canPerformAction = canPerformAction
 		self.canBeMoved = canBeMoved
 		self.visibilityAction = visibilityAction
 		self.previewingViewControllerAction = previewingViewControllerAction
 	}
 	
-	public init(canSelectAction: CanSelectAction? = nil,
-				selectionAction: SelectionAction? = nil,
-				deselectionAction: DeselectionAction? = nil,
-				rowActions: [UITableViewRowAction]? = nil,
-				canPerformAction: CanPerformAction? = nil,
-				canBeMoved: Bool = false,
-				visibilityAction: VisibilityAction? = nil,
-				previewingViewControllerAction: @escaping () -> UIViewController?) {
+	internal var hasEditActions: Bool {
+		return leadingActionConfiguration != nil || trailingActionConfiguration != nil || rowActions != nil
+	}
+}
+
+// MARK: - Backwards Compatible Initializers
+
+public extension CellActions {
+	/// Backwards compatible initializer that accepts `rowActions` instead of `leadingActionConfiguration` and `trailingActionConfiguration`
+	init(
+		canSelectAction: CanSelectAction? = nil,
+		selectionAction: SelectionAction? = nil,
+		deselectionAction: DeselectionAction? = nil,
+		rowActions: [UITableViewRowAction]?,
+		canPerformAction: CanPerformAction? = nil,
+		canBeMoved: Bool = false,
+		visibilityAction: VisibilityAction? = nil,
+		previewingViewControllerAction: PreviewingViewControllerAction? = nil) {
+		self.canSelectAction = canSelectAction
+		self.selectionAction = selectionAction
+		self.deselectionAction = deselectionAction
+		self.rowActions = rowActions
+		self.leadingActionConfiguration = nil
+		self.trailingActionConfiguration = nil
+		self.canPerformAction = canPerformAction
+		self.canBeMoved = canBeMoved
+		self.visibilityAction = visibilityAction
+		self.previewingViewControllerAction = previewingViewControllerAction
+	}
+	
+	/// Backwards compatible initializer that wraps the `previewingViewControllerAction` to the new form.
+	init(
+		canSelectAction: CanSelectAction? = nil,
+		selectionAction: SelectionAction? = nil,
+		deselectionAction: DeselectionAction? = nil,
+		rowActions: [UITableViewRowAction]? = nil,
+		canPerformAction: CanPerformAction? = nil,
+		canBeMoved: Bool = false,
+		visibilityAction: VisibilityAction? = nil,
+		previewingViewControllerAction: @escaping () -> UIViewController?) {
 		let wrappedPreviewingViewControllerAction: PreviewingViewControllerAction = { (cell, _, previewingContext) in
 			previewingContext.sourceRect = previewingContext.sourceView.convert(cell.bounds, from: cell)
 			return previewingViewControllerAction()
 		}
-		self.init(canSelectAction: canSelectAction, selectionAction: selectionAction, deselectionAction: deselectionAction, rowActions: rowActions, canPerformAction: canPerformAction, canBeMoved: canBeMoved, visibilityAction: visibilityAction, previewingViewControllerAction: wrappedPreviewingViewControllerAction)
+		self.init(
+			canSelectAction: canSelectAction,
+			selectionAction: selectionAction,
+			deselectionAction: deselectionAction,
+			rowActions: rowActions,
+			canPerformAction: canPerformAction,
+			canBeMoved: canBeMoved,
+			visibilityAction: visibilityAction,
+			previewingViewControllerAction: wrappedPreviewingViewControllerAction)
 	}
 }

--- a/FunctionalTableData/CellActions.swift
+++ b/FunctionalTableData/CellActions.swift
@@ -142,7 +142,6 @@ public struct CellActions {
 	public let deselectionAction: SelectionAction?
 	
 	/// All the available row actions this cell can perform. See [UITableViewRowAction](https://developer.apple.com/documentation/uikit/uitableviewrowaction) for more info.
-	//@available(*, deprecated, message: "Use `trailingActionConfiguration` instead.")
 	public let rowActions: [UITableViewRowAction]?
 	
 	/// The swipe actions to display on the leading edge of the row.
@@ -195,6 +194,7 @@ public struct CellActions {
 
 public extension CellActions {
 	/// Backwards compatible initializer that accepts `rowActions` instead of `leadingActionConfiguration` and `trailingActionConfiguration`
+	@available(*, deprecated, message: "Use init with `trailingActionConfiguration` instead.")
 	init(
 		canSelectAction: CanSelectAction? = nil,
 		selectionAction: SelectionAction? = nil,
@@ -217,6 +217,7 @@ public extension CellActions {
 	}
 	
 	/// Backwards compatible initializer that wraps the `previewingViewControllerAction` to the new form.
+	@available(*, deprecated, message: "Use init with previewingViewControllerAction of type `PreviewingViewControllerAction`")
 	init(
 		canSelectAction: CanSelectAction? = nil,
 		selectionAction: SelectionAction? = nil,

--- a/FunctionalTableData/TableView/FunctionalTableData+UITableViewDataSource.swift
+++ b/FunctionalTableData/TableView/FunctionalTableData+UITableViewDataSource.swift
@@ -50,8 +50,8 @@ extension FunctionalTableData {
 		}
 		
 		public func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
-			let cellConfig = sections[indexPath]
-			return cellConfig?.actions.rowActions != nil || self.tableView(tableView, canMoveRowAt: indexPath)
+			guard let cellConfig = sections[indexPath] else { return false }
+			return cellConfig.actions.hasEditActions || self.tableView(tableView, canMoveRowAt: indexPath)
 		}
 	}
 }

--- a/FunctionalTableData/TableView/FunctionalTableData+UITableViewDelegate.swift
+++ b/FunctionalTableData/TableView/FunctionalTableData+UITableViewDelegate.swift
@@ -205,7 +205,19 @@ extension FunctionalTableData {
 		
 		public func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
 			let cellConfig = sections[indexPath]
-			return cellConfig?.actions.rowActions
+			return cellConfig?.actions.trailingActionConfiguration?.asRowActions(in: tableView) ?? cellConfig?.actions.rowActions
+		}
+		
+		@available(iOSApplicationExtension 11.0, *)
+		public func tableView(_ tableView: UITableView, leadingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+			let cellConfig = sections[indexPath]
+			return cellConfig?.actions.leadingActionConfiguration?.asSwipeActionsConfiguration()
+		}
+
+		@available(iOSApplicationExtension 11.0, *)
+		public func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+			let cellConfig = sections[indexPath]
+			return cellConfig?.actions.trailingActionConfiguration?.asSwipeActionsConfiguration()
 		}
 	}
 }

--- a/FunctionalTableDataTests/FunctionalTableDataDelegateTests.swift
+++ b/FunctionalTableDataTests/FunctionalTableDataDelegateTests.swift
@@ -1,0 +1,45 @@
+//
+//  FunctionalTableDataDelegateTests.swift
+//  FunctionalTableDataTests
+//
+//  Created by Geoffrey Foster on 2019-04-01.
+//  Copyright © 2019 Shopify. All rights reserved.
+//
+
+import XCTest
+@testable import FunctionalTableData
+
+class FunctionalTableDataDelegateTests: XCTestCase {
+	let tableView = UITableView(frame: .zero, style: .plain)
+	
+	func testLeadingTrailingRowActions() {
+		let actions = CellActions(
+			leadingActionConfiguration: CellActions.SwipeActionsConfiguration(
+				actions: [
+					CellActions.SwipeActionsConfiguration.ContextualAction(title: "Hi", style: .normal, handler: { (_, _) in })
+				]
+			),
+			trailingActionConfiguration: CellActions.SwipeActionsConfiguration(
+				actions: [
+					CellActions.SwipeActionsConfiguration.ContextualAction(title: "Bye", style: .normal, handler: { (_, _) in })
+				]
+			)
+		)
+		let cell = HostCell<UIView, String, LayoutMarginsTableItemLayout>(key: "actions", actions: actions, state: "Actions") { (_, _) in }
+		let delegate = FunctionalTableData.Delegate()
+		delegate.sections = [TableSection(key: "Section", rows: [cell])]
+		let indexPath = IndexPath(row: 0, section: 0)
+		
+		let rowActions = delegate.tableView(tableView, editActionsForRowAt: indexPath)
+		XCTAssertNotNil(rowActions)
+		XCTAssertEqual(rowActions?.first?.title, "Bye")
+		
+		let leadingSwipeActionsConfiguration = delegate.tableView(tableView, leadingSwipeActionsConfigurationForRowAt: indexPath)
+		XCTAssertNotNil(leadingSwipeActionsConfiguration)
+		XCTAssertEqual(leadingSwipeActionsConfiguration?.actions.first?.title, "Hi")
+		
+		let trailingActionConfiguration = delegate.tableView(tableView, trailingSwipeActionsConfigurationForRowAt: indexPath)
+		XCTAssertNotNil(trailingActionConfiguration)
+		XCTAssertEqual(trailingActionConfiguration?.actions.first?.title, "Bye")
+	}
+}


### PR DESCRIPTION
Supersedes row actions on iOS 11+
Keeps backwards compatibility on iOS < 11 by using the new action struct types and mapping into UITableViewRowAction objects as needed.

I've mapped the UISwipeActionsConfiguration and UIContextualAction types to our own struct types. This allowed me to vend UITableViewRowAction's in the iOS 9/10 case by creating them on demand. Otherwise, the appropriate swipe configuration objects are created (on demand) in the respective delegate methods. I dropped the one item from the handler closure (the context action itself) as I couldn't see a real use for this. You can't manipulate a context action within the closure (I tried) so it seems pointless to pass it through (and wouldn't work well for mapping to the iOS 9/10 case).

I've re-jigged the initializers a bit as well. There's no way to init a CellAction with both leading/trailing configuration and rowActions, only one set or the other.