### PR TITLE
reverting partial change and adding comment to explain what needs to happen

### DIFF
--- a/FunctionalTableData/TableView/FunctionalTableData+UITableViewDelegate.swift
+++ b/FunctionalTableData/TableView/FunctionalTableData+UITableViewDelegate.swift
@@ -190,6 +190,12 @@ extension FunctionalTableData {
 			// required
 		}
 		
+		public func tableView(_ tableView: UITableView, editingStyleForRowAt indexPath: IndexPath) -> UITableViewCell.EditingStyle {
+			let cellConfig = sections[indexPath]
+			// FIXME: This is a temporary revert of a semi-breaking change. Having actions associated with row shouldn't dictate if the delete action is available when the UITableView is in edit mode. Having a `canDelete` property, or a `deleteAction` would better serve the intent here
+			return cellConfig?.actions.leadingActionConfiguration != nil || cellConfig?.actions.trailingActionConfiguration != nil ? .delete : .none
+		}
+		
 		public func tableView(_ tableView: UITableView, shouldIndentWhileEditingRowAt indexPath: IndexPath) -> Bool {
 			return false
 		}


### PR DESCRIPTION
Without this function the delete indicators show up when a table is in edit mode, even when we don't want them to. Adding this back allows them to be suppressed for now until a better solution is implemented