### PR TITLE
Add separator style inset on both sides

### DIFF
--- a/FunctionalTableData/Separator.swift
+++ b/FunctionalTableData/Separator.swift
@@ -21,20 +21,25 @@ public class Separator: UIView {
 	
 	/// The style for table cells used as separators.
 	///
-	/// The options are `full`, `inset`, and `moreInset`
-	public enum Style {
+	/// The options are `full`, `inset`, `moreInset`, `custom`
+	public enum Style: Equatable {
 		case full
 		case inset
 		case moreInset
+		case custom(leadingInset: CGFloat, trailingInset: CGFloat, layoutMarginsRelative: Bool)
 		
-		public var insetDistance: CGFloat {
-			switch self {
-			case .inset:
-				return Separator.inset
-			case .full:
-				return 0
-			case .moreInset:
-				return 3 * Separator.inset
+		public static func ==(lhs: Style, rhs: Style) -> Bool {
+			switch (lhs, rhs) {
+			case let (.custom(lhsLeadingInset, lhsTrailingInset, lhsLayoutMargins), .custom(rhsLeadingInset, rhsTrailingInset, rhsLayoutMargins)):
+				return lhsLeadingInset == rhsLeadingInset && lhsTrailingInset == rhsTrailingInset && lhsLayoutMargins == rhsLayoutMargins
+			case (.full, .full):
+				return true
+			case (.inset, .inset):
+				return true
+			case (.moreInset, .moreInset):
+				return true
+			default:
+				return false
 			}
 		}
 	}
@@ -72,12 +77,30 @@ public class Separator: UIView {
 	}
 
 	private func applyHorizontalConstraints(_ view: UIView) {
-		trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
 		switch style {
-		case .full, .moreInset:
-			leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: style.insetDistance).isActive = true
+		case .full, .inset, .moreInset:
+			trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
+		case .custom(_, let trailingInset, let layoutMarginsRelative):
+			if layoutMarginsRelative {
+				trailingAnchor.constraint(equalTo: view.layoutMarginsGuide.trailingAnchor, constant: -trailingInset).isActive = true
+			} else {
+				trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -trailingInset).isActive = true
+			}
+		}
+		
+		switch style {
+		case .full:
+			leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
+		case .moreInset:
+			leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 3 * Separator.inset).isActive = true
 		case .inset:
 			leadingAnchor.constraint(equalTo: view.layoutMarginsGuide.leadingAnchor).isActive = true
+		case .custom(let leadingInset, _, let layoutMarginsRelative):
+			if layoutMarginsRelative {
+				leadingAnchor.constraint(equalTo: view.layoutMarginsGuide.leadingAnchor, constant: leadingInset).isActive = true
+			} else {
+				leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: leadingInset).isActive = true
+			}
 		}
 	}
 }

--- a/FunctionalTableDataTests/CellStyleTests.swift
+++ b/FunctionalTableDataTests/CellStyleTests.swift
@@ -63,7 +63,7 @@ class StyleTests: XCTestCase {
 		separator = cell.viewWithTag(Separator.Tag.bottom.rawValue)
 		cell.layoutIfNeeded()
 		XCTAssertNotNil(separator)
-		XCTAssertEqual(separator!.bounds.width, cell.bounds.width - Separator.Style.moreInset.insetDistance)
+		XCTAssertEqual(separator!.bounds.width, cell.bounds.width - 3 * Separator.inset)
 		
 		style.bottomSeparator = nil
 		style.configure(cell: cell, in: table)
@@ -91,7 +91,7 @@ class StyleTests: XCTestCase {
 		separator = cell.viewWithTag(Separator.Tag.top.rawValue)
 		cell.layoutIfNeeded()
 		XCTAssertNotNil(separator)
-		XCTAssertEqual(separator!.bounds.width, cell.bounds.width - Separator.Style.moreInset.insetDistance)
+		XCTAssertEqual(separator!.bounds.width, cell.bounds.width - 3 * Separator.inset)
 		
 		style.topSeparator = nil
 		style.configure(cell: cell, in: table)


### PR DESCRIPTION
We have a new design for separators that are inset on both sides (so they appear in the centre). This adds a new style to `Separator` called `bothInset` (naming suggestions very welcome!) that anchors the separator to the layout margins on both sides.

Technically adding a new enum value is a breaking change since it would require anyone that uses it in a switch statement without a `default` to add the new case, but I feel like most people aren't checking this enum in a switch statement outside of FTD.