### PR TITLE
Adds the isSameKind function

### DIFF
--- a/FunctionalTableData/CellConfigType.swift
+++ b/FunctionalTableData/CellConfigType.swift
@@ -45,4 +45,19 @@ public protocol CellConfigType: TableItemConfigType, CollectionItemConfigType {
 	/// - Returns: `true` when both values are the same, `false` otherwise.
 	func isEqual(_ other: CellConfigType) -> Bool
 	func debugInfo() -> [String: Any]
+	
+	/// Compares self against another `CellConfigType` to determine if they should be counted as being the same type.
+	///
+	/// - note: This should almost never need to be implemented. The default version of it, provided as a protocol extension,
+	///   does the expected thing (and compares `type(of:)` to `type(of:)`. This is inteded for test cases to be able to override.
+	///
+	/// - Parameter other: The other `CellConfigType` to compare against.
+	/// - Returns: `true` if the same type, `false` otherwise
+	func isSameKind(as other: CellConfigType) -> Bool
+}
+
+public extension CellConfigType {
+	func isSameKind(as other: CellConfigType) -> Bool {
+		return type(of: self) == type(of: other)
+	}
 }

--- a/FunctionalTableData/CellConfigType.swift
+++ b/FunctionalTableData/CellConfigType.swift
@@ -49,7 +49,7 @@ public protocol CellConfigType: TableItemConfigType, CollectionItemConfigType {
 	/// Compares self against another `CellConfigType` to determine if they should be counted as being the same type.
 	///
 	/// - note: This should almost never need to be implemented. The default version of it, provided as a protocol extension,
-	///   does the expected thing (and compares `type(of:)` to `type(of:)`. This is inteded for test cases to be able to override.
+	///   does the expected thing (and compares `type(of:)` to `type(of:)`. This is intended for test cases to be able to override.
 	///
 	/// - Parameter other: The other `CellConfigType` to compare against.
 	/// - Returns: `true` if the same type, `false` otherwise

--- a/FunctionalTableData/HostCell.swift
+++ b/FunctionalTableData/HostCell.swift
@@ -101,7 +101,7 @@ public struct HostCell<View, State, Layout>: CellConfigType where View: UIView, 
 	}
 	
 	public func debugInfo() -> [String: Any] {
-		let debugInfo: [String: Any] = ["key": key]
+		let debugInfo: [String: Any] = ["key": key, "type": String(describing: type(of: self))]
 		return debugInfo
 	}
 }

--- a/FunctionalTableData/TableSectionChangeSet.swift
+++ b/FunctionalTableData/TableSectionChangeSet.swift
@@ -225,7 +225,7 @@ public final class TableSectionChangeSet {
 						let newRow = newSection[newRowIndex]
 						// Compare existing row
 						if visibleIndexPaths.contains(IndexPath(row: oldRowIndex, section: oldSectionIndex)) && !isRow(new: (section: newSection, row: newRowIndex), equalTo: (section: oldSection, row: oldRowIndex)) {
-							if type(of: newRow) == type(of: oldSection[oldRowIndex]) {
+							if newRow.isSameKind(as: oldSection[oldRowIndex]) {
 								updates.append(Update(
 									index: IndexPath(row: newRowIndex, section: newSectionIndex),
 									cellConfig: newRow
@@ -249,7 +249,7 @@ public final class TableSectionChangeSet {
 						from: IndexPath(row: oldRowIndexLocation, section: oldSectionIndex),
 						to: IndexPath(row: newRowIndex, section: newSectionIndex)))
 					if visibleIndexPaths.contains(IndexPath(row: oldRowIndexLocation, section: oldSectionIndex)) && !isRow(new: (section: newSection, row: newRowIndex), equalTo: (section: oldSection, row: oldRowIndexLocation)) {
-						if type(of: newRow) == type(of: oldSection[oldRowIndex]) {
+						if newRow.isSameKind(as: oldSection[oldRowIndex]) {
 							updates.append(Update(
 								index: IndexPath(row: newRowIndex, section: newSectionIndex),
 								cellConfig: newRow


### PR DESCRIPTION
Moves the `type(of:)` comparisons into an overridable function that can be used in tests.
Captures the type of a cell in its `debugInfo()`

With this change I'm able to simulate different "types" of cells in test cases by having a custom type that conforms to CellConfigType and has the `isSameKind` function implemented. Additionally, capturing the type of a cell in a crash means that that data can be used in conjunction with the isSameKind