### PR TITLE
Fix invalid index paths on reload and an incorrect compare for updates

### DIFF
--- a/FunctionalTableData/TableSectionChangeSet.swift
+++ b/FunctionalTableData/TableSectionChangeSet.swift
@@ -231,7 +231,7 @@ public final class TableSectionChangeSet {
 									cellConfig: newRow
 								))
 							} else {
-								reloadedRows.append(IndexPath(row: newRowIndex, section: newSectionIndex))
+								reloadedRows.append(IndexPath(row: oldRowIndex, section: oldSectionIndex))
 							}
 						}
 						oldRowIndex += 1
@@ -249,13 +249,13 @@ public final class TableSectionChangeSet {
 						from: IndexPath(row: oldRowIndexLocation, section: oldSectionIndex),
 						to: IndexPath(row: newRowIndex, section: newSectionIndex)))
 					if visibleIndexPaths.contains(IndexPath(row: oldRowIndexLocation, section: oldSectionIndex)) && !isRow(new: (section: newSection, row: newRowIndex), equalTo: (section: oldSection, row: oldRowIndexLocation)) {
-						if newRow.isSameKind(as: oldSection[oldRowIndex]) {
+						if newRow.isSameKind(as: oldSection[oldRowIndexLocation]) {
 							updates.append(Update(
 								index: IndexPath(row: newRowIndex, section: newSectionIndex),
 								cellConfig: newRow
 							))
 						} else {
-							reloadedRows.append(IndexPath(row: newRowIndex, section: newSectionIndex))
+							reloadedRows.append(IndexPath(row: oldRowIndexLocation, section: oldSectionIndex))
 						}
 					}
 					newRowIndex += 1


### PR DESCRIPTION
- when comparing the old/new types, compare against the proper old index path
- reloads require the before IndexPath, fixes to use that instead of the new IndexPath