### PR TITLE
Move sections to a TableData class instead of duplicating the array

### DIFF
--- a/FunctionalTableData.xcodeproj/project.pbxproj
+++ b/FunctionalTableData.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		6C5F34C92232E8D300D57BEA /* FunctionalCollectionData+UICollectionViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C5F34C82232E8D300D57BEA /* FunctionalCollectionData+UICollectionViewDelegate.swift */; };
 		6C5F34CB2232E99000D57BEA /* FunctionalCollectionData+UICollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C5F34CA2232E99000D57BEA /* FunctionalCollectionData+UICollectionViewDataSource.swift */; };
 		6C910BA922529B390000D7E9 /* FunctionalTableDataDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C910BA822529B390000D7E9 /* FunctionalTableDataDelegateTests.swift */; };
+		8F3A07AB2277999D00BBA836 /* FunctionalTableData+Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F3A07AA2277999D00BBA836 /* FunctionalTableData+Data.swift */; };
 		9FF97DB3212CA23B006FA047 /* TableCellReuseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FF97DB2212CA23B006FA047 /* TableCellReuseTests.swift */; };
 		BC8C5D4121763B7B00443E28 /* BackgroundViewProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC8C5D4021763B7B00443E28 /* BackgroundViewProvider.swift */; };
 /* End PBXBuildFile section */
@@ -138,6 +139,7 @@
 		6C5F34C82232E8D300D57BEA /* FunctionalCollectionData+UICollectionViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FunctionalCollectionData+UICollectionViewDelegate.swift"; sourceTree = "<group>"; };
 		6C5F34CA2232E99000D57BEA /* FunctionalCollectionData+UICollectionViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FunctionalCollectionData+UICollectionViewDataSource.swift"; sourceTree = "<group>"; };
 		6C910BA822529B390000D7E9 /* FunctionalTableDataDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunctionalTableDataDelegateTests.swift; sourceTree = "<group>"; };
+		8F3A07AA2277999D00BBA836 /* FunctionalTableData+Data.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FunctionalTableData+Data.swift"; sourceTree = "<group>"; };
 		9FF97DB2212CA23B006FA047 /* TableCellReuseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableCellReuseTests.swift; sourceTree = "<group>"; };
 		BC8C5D4021763B7B00443E28 /* BackgroundViewProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundViewProvider.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -277,6 +279,7 @@
 			isa = PBXGroup;
 			children = (
 				4C7A27711F2FB55D00360E9B /* FunctionalTableData.swift */,
+				8F3A07AA2277999D00BBA836 /* FunctionalTableData+Data.swift */,
 				6C507AF52249268900D04521 /* FunctionalTableData+Cells.swift */,
 				6C5F34C62232D15500D57BEA /* FunctionalTableData+UITableViewDataSource.swift */,
 				6C5F34C42232D14B00D57BEA /* FunctionalTableData+UITableViewDelegate.swift */,
@@ -481,6 +484,7 @@
 				6C5F34CB2232E99000D57BEA /* FunctionalCollectionData+UICollectionViewDataSource.swift in Sources */,
 				4C7A27801F2FB55D00360E9B /* Reusable.swift in Sources */,
 				4C63250D1F8AA8A000B2B74B /* UITableView+Reusable.swift in Sources */,
+				8F3A07AB2277999D00BBA836 /* FunctionalTableData+Data.swift in Sources */,
 				4C7A277B1F2FB55D00360E9B /* CellActions.swift in Sources */,
 				4C6325131F8AA8A400B2B74B /* FunctionalCollectionData.swift in Sources */,
 				3624340420D2F40100A75787 /* Array+TableSection.swift in Sources */,

--- a/FunctionalTableData/TableView/FunctionalTableData+Cells.swift
+++ b/FunctionalTableData/TableView/FunctionalTableData+Cells.swift
@@ -10,17 +10,21 @@ import Foundation
 
 extension FunctionalTableData {
 	class CellStyler {
-		var sections: [TableSection] = []
+		var data: TableData
 		var highlightedRow: ItemPath?
 		
+		init(data: TableData) {
+			self.data = data
+		}
+		
 		func highlightRow(at itemPath: ItemPath?, animated: Bool, in tableView: UITableView) {
-			if let highlightedRow = highlightedRow, let currentlyHighlightedIndexPath = sections.indexPath(from: highlightedRow), let currentlyHighlightedCell = tableView.cellForRow(at: currentlyHighlightedIndexPath) {
+			if let highlightedRow = highlightedRow, let currentlyHighlightedIndexPath = data.sections.indexPath(from: highlightedRow), let currentlyHighlightedCell = tableView.cellForRow(at: currentlyHighlightedIndexPath) {
 				currentlyHighlightedCell.setHighlighted(false, animated: animated)
 			}
 			
 			highlightedRow = itemPath
 			
-			guard let itemPath = itemPath, let indexPath = sections.indexPath(from: itemPath), let cell = tableView.cellForRow(at: indexPath) else { return }
+			guard let itemPath = itemPath, let indexPath = data.sections.indexPath(from: itemPath), let cell = tableView.cellForRow(at: indexPath) else { return }
 			
 			if cell.isHighlighted || cell.isSelected {
 				return
@@ -34,7 +38,7 @@ extension FunctionalTableData {
 		}
 		
 		func update(cell: UITableViewCell, cellConfig: CellConfigType, at indexPath: IndexPath, in tableView: UITableView) {
-			let section = sections[indexPath.section]
+			let section = data.sections[indexPath.section]
 			cellConfig.update(cell: cell, in: tableView)
 			let style = section.mergedStyle(for: indexPath.row)
 			style.configure(cell: cell, in: tableView)

--- a/FunctionalTableData/TableView/FunctionalTableData+Cells.swift
+++ b/FunctionalTableData/TableView/FunctionalTableData+Cells.swift
@@ -10,7 +10,7 @@ import Foundation
 
 extension FunctionalTableData {
 	class CellStyler {
-		var data: TableData
+		let data: TableData
 		var highlightedRow: ItemPath?
 		
 		init(data: TableData) {

--- a/FunctionalTableData/TableView/FunctionalTableData+Data.swift
+++ b/FunctionalTableData/TableView/FunctionalTableData+Data.swift
@@ -1,0 +1,14 @@
+//
+//  FunctionalTableData+Data.swift
+//  FunctionalTableData
+//
+//  Created by Pierre Oleo on 2019-04-29.
+//  Copyright © 2019 Shopify. All rights reserved.
+//
+
+import Foundation
+extension FunctionalTableData {
+	class TableData {
+		var sections: [TableSection] = []
+	}
+}

--- a/FunctionalTableData/TableView/FunctionalTableData+UITableViewDataSource.swift
+++ b/FunctionalTableData/TableView/FunctionalTableData+UITableViewDataSource.swift
@@ -10,7 +10,7 @@ import Foundation
 
 extension FunctionalTableData {
 	class DataSource: NSObject, UITableViewDataSource {
-		var data: TableData
+		private let data: TableData
 		private var cellStyler: CellStyler
 		
 		init(cellStyler: CellStyler) {

--- a/FunctionalTableData/TableView/FunctionalTableData+UITableViewDataSource.swift
+++ b/FunctionalTableData/TableView/FunctionalTableData+UITableViewDataSource.swift
@@ -10,23 +10,24 @@ import Foundation
 
 extension FunctionalTableData {
 	class DataSource: NSObject, UITableViewDataSource {
-		var sections: [TableSection] = []
+		var data: TableData
 		private var cellStyler: CellStyler
 		
 		init(cellStyler: CellStyler) {
 			self.cellStyler = cellStyler
+			self.data = cellStyler.data
 		}
 		
 		public func numberOfSections(in tableView: UITableView) -> Int {
-			return sections.count
+			return data.sections.count
 		}
 		
 		public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-			return sections[section].rows.count
+			return data.sections[section].rows.count
 		}
 		
 		public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-			let sectionData = sections[indexPath.section]
+			let sectionData = data.sections[indexPath.section]
 			let row = indexPath.row
 			let cellConfig = sectionData[row]
 			let cell = cellConfig.dequeueCell(from: tableView, at: indexPath)
@@ -42,17 +43,17 @@ extension FunctionalTableData {
 			assert(sourceIndexPath.section == destinationIndexPath.section)
 			
 			// Update internal state to match move
-			let cell = sections[sourceIndexPath.section].rows.remove(at: sourceIndexPath.row)
-			sections[destinationIndexPath.section].rows.insert(cell, at: destinationIndexPath.row)
-			sections[sourceIndexPath.section].didMoveRow?(sourceIndexPath.row, destinationIndexPath.row)
+			let cell = data.sections[sourceIndexPath.section].rows.remove(at: sourceIndexPath.row)
+			data.sections[destinationIndexPath.section].rows.insert(cell, at: destinationIndexPath.row)
+			data.sections[sourceIndexPath.section].didMoveRow?(sourceIndexPath.row, destinationIndexPath.row)
 		}
 		
 		public func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
-			return sections[indexPath]?.actions.canBeMoved ?? false
+			return data.sections[indexPath]?.actions.canBeMoved ?? false
 		}
 		
 		public func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
-			guard let cellConfig = sections[indexPath] else { return false }
+			guard let cellConfig = data.sections[indexPath] else { return false }
 			return cellConfig.actions.hasEditActions || self.tableView(tableView, canMoveRowAt: indexPath)
 		}
 	}

--- a/FunctionalTableData/TableView/FunctionalTableData+UITableViewDelegate.swift
+++ b/FunctionalTableData/TableView/FunctionalTableData+UITableViewDelegate.swift
@@ -10,7 +10,7 @@ import Foundation
 
 extension FunctionalTableData {
 	class Delegate: NSObject, UITableViewDelegate {
-		var sections: [TableSection] = []
+		var data: TableData
 		private var heightAtIndexKeyPath: [ItemPath: CGFloat] = [:]
 		private var cellStyler: CellStyler
 		
@@ -19,6 +19,7 @@ extension FunctionalTableData {
 		
 		init(cellStyler: CellStyler) {
 			self.cellStyler = cellStyler
+			self.data = cellStyler.data
 		}
 		
 		public override func responds(to aSelector: Selector!) -> Bool {
@@ -44,7 +45,7 @@ extension FunctionalTableData {
 		}
 		
 		public func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-			guard let header = sections[section].header else {
+			guard let header = data.sections[section].header else {
 				// When given a height of zero grouped style UITableView's use their default value instead of zero. By returning CGFloat.min we get around this behavior and force UITableView to end up using a height of zero after all.
 				return tableView.style == .grouped ? CGFloat.leastNormalMagnitude : 0
 			}
@@ -52,7 +53,7 @@ extension FunctionalTableData {
 		}
 		
 		public func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-			guard let footer = sections[section].footer else {
+			guard let footer = data.sections[section].footer else {
 				// When given a height of zero grouped style UITableView's use their default value instead of zero. By returning CGFloat.min we get around this behavior and force UITableView to end up using a height of zero after all.
 				return tableView.style == .grouped ? CGFloat.leastNormalMagnitude : 0
 			}
@@ -60,8 +61,8 @@ extension FunctionalTableData {
 		}
 		
 		public func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
-			guard indexPath.section < sections.count else { return UITableView.automaticDimension }
-			if let indexKeyPath = sections[indexPath.section].sectionKeyPathForRow(indexPath.row), let height = heightAtIndexKeyPath[indexKeyPath] {
+			guard indexPath.section < data.sections.count else { return UITableView.automaticDimension }
+			if let indexKeyPath = data.sections[indexPath.section].sectionKeyPathForRow(indexPath.row), let height = heightAtIndexKeyPath[indexKeyPath] {
 				return height
 			} else {
 				return UITableView.automaticDimension
@@ -69,17 +70,17 @@ extension FunctionalTableData {
 		}
 		
 		public func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-			guard let header = sections[section].header else { return nil }
+			guard let header = data.sections[section].header else { return nil }
 			return header.dequeueHeaderFooter(from: tableView)
 		}
 		
 		public func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
-			guard let footer = sections[section].footer else { return nil }
+			guard let footer = data.sections[section].footer else { return nil }
 			return footer.dequeueHeaderFooter(from: tableView)
 		}
 		
 		public func tableView(_ tableView: UITableView, shouldHighlightRowAt indexPath: IndexPath) -> Bool {
-			let cellConfig = sections[indexPath]
+			let cellConfig = data.sections[indexPath]
 			return cellConfig?.actions.selectionAction != nil
 		}
 		
@@ -88,11 +89,11 @@ extension FunctionalTableData {
 				return nil
 			}
 			
-			guard let cellConfig = sections[indexPath] else {
+			guard let cellConfig = data.sections[indexPath] else {
 				return nil
 			}
 			
-			let keyPath = sections.itemPath(from: indexPath)
+			let keyPath = data.sections.itemPath(from: indexPath)
 			
 			if let canSelectAction = cellConfig.actions.canSelectAction {
 				let canSelectResult: (Bool) -> Void = { selected in
@@ -119,7 +120,7 @@ extension FunctionalTableData {
 		
 		public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
 			guard let cell = tableView.cellForRow(at: indexPath) else { return }
-			let cellConfig = sections[indexPath]
+			let cellConfig = data.sections[indexPath]
 			
 			let selectionState = cellConfig?.actions.selectionAction?(cell) ?? .deselected
 			if selectionState == .deselected {
@@ -131,7 +132,7 @@ extension FunctionalTableData {
 		
 		public func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {
 			guard let cell = tableView.cellForRow(at: indexPath) else { return }
-			let cellConfig = sections[indexPath]
+			let cellConfig = data.sections[indexPath]
 			
 			let selectionState = cellConfig?.actions.deselectionAction?(cell) ?? .deselected
 			if selectionState == .selected {
@@ -142,43 +143,43 @@ extension FunctionalTableData {
 		}
 		
 		public func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
-			guard indexPath.section < sections.count else { return }
+			guard indexPath.section < data.sections.count else { return }
 			
-			if let indexKeyPath = sections[indexPath.section].sectionKeyPathForRow(indexPath.row) {
+			if let indexKeyPath = data.sections[indexPath.section].sectionKeyPathForRow(indexPath.row) {
 				heightAtIndexKeyPath[indexKeyPath] = cell.bounds.height
 			}
 			
-			if let cellConfig = sections[indexPath] {
+			if let cellConfig = data.sections[indexPath] {
 				cellConfig.actions.visibilityAction?(cell, true)
 				return
 			}
 		}
 		
 		public func tableView(_ tableView: UITableView, didEndDisplaying cell: UITableViewCell, forRowAt indexPath: IndexPath) {
-			if let cellConfig = sections[indexPath] {
+			if let cellConfig = data.sections[indexPath] {
 				cellConfig.actions.visibilityAction?(cell, false)
 				return
 			}
 		}
 		
 		public func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
-			let tableSection = sections[section]
+			let tableSection = data.sections[section]
 			tableSection.headerVisibilityAction?(view, true)
 		}
 		
 		public func tableView(_ tableView: UITableView, didEndDisplayingHeaderView view: UIView, forSection section: Int) {
-			guard section < sections.count else { return }
-			let tableSection = sections[section]
+			guard section < data.sections.count else { return }
+			let tableSection = data.sections[section]
 			tableSection.headerVisibilityAction?(view, false)
 		}
 		
 		public func tableView(_ tableView: UITableView, shouldShowMenuForRowAt indexPath: IndexPath) -> Bool {
-			let cellConfig = sections[indexPath]
+			let cellConfig = data.sections[indexPath]
 			return cellConfig?.actions.canPerformAction != nil
 		}
 		
 		public func tableView(_ tableView: UITableView, canPerformAction action: Selector, forRowAt indexPath: IndexPath, withSender sender: Any?) -> Bool {
-			let cellConfig = sections[indexPath]
+			let cellConfig = data.sections[indexPath]
 			return cellConfig?.actions.canPerformAction?(action) ?? false
 		}
 		
@@ -187,7 +188,7 @@ extension FunctionalTableData {
 		}
 		
 		public func tableView(_ tableView: UITableView, editingStyleForRowAt indexPath: IndexPath) -> UITableViewCell.EditingStyle {
-			let cellConfig = sections[indexPath]
+			let cellConfig = data.sections[indexPath]
 			// FIXME: This is a temporary revert of a semi-breaking change. Having actions associated with row shouldn't dictate if the delete action is available when the UITableView is in edit mode. Having a `canDelete` property, or a `deleteAction` would better serve the intent here
 			return cellConfig?.actions.leadingActionConfiguration != nil || cellConfig?.actions.trailingActionConfiguration != nil ? .delete : .none
 		}
@@ -201,19 +202,19 @@ extension FunctionalTableData {
 		}
 		
 		public func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
-			let cellConfig = sections[indexPath]
+			let cellConfig = data.sections[indexPath]
 			return cellConfig?.actions.trailingActionConfiguration?.asRowActions(in: tableView)
 		}
 		
 		@available(iOSApplicationExtension 11.0, *)
 		public func tableView(_ tableView: UITableView, leadingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
-			let cellConfig = sections[indexPath]
+			let cellConfig = data.sections[indexPath]
 			return cellConfig?.actions.leadingActionConfiguration?.asSwipeActionsConfiguration()
 		}
 
 		@available(iOSApplicationExtension 11.0, *)
 		public func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
-			let cellConfig = sections[indexPath]
+			let cellConfig = data.sections[indexPath]
 			return cellConfig?.actions.trailingActionConfiguration?.asSwipeActionsConfiguration()
 		}
 	}

--- a/FunctionalTableData/TableView/FunctionalTableData+UITableViewDelegate.swift
+++ b/FunctionalTableData/TableView/FunctionalTableData+UITableViewDelegate.swift
@@ -10,7 +10,7 @@ import Foundation
 
 extension FunctionalTableData {
 	class Delegate: NSObject, UITableViewDelegate {
-		var data: TableData
+		private let data: TableData
 		private var heightAtIndexKeyPath: [ItemPath: CGFloat] = [:]
 		private var cellStyler: CellStyler
 		

--- a/FunctionalTableData/TableView/FunctionalTableData.swift
+++ b/FunctionalTableData/TableView/FunctionalTableData.swift
@@ -41,20 +41,18 @@ public class FunctionalTableData {
 	
 	private func dumpDebugInfoForChanges(_ changes: TableSectionChangeSet, previousSections: [TableSection], visibleIndexPaths: [IndexPath], exceptionReason: String?, exceptionUserInfo: [AnyHashable: Any]?) {
 		guard let exceptionHandler = FunctionalTableData.exceptionHandler else { return }
-		let exception = Exception(name: name, newSections: sections, oldSections: previousSections, changes: changes, visible: visibleIndexPaths, viewFrame: tableView?.frame ?? .zero, reason: exceptionReason, userInfo: exceptionUserInfo)
+		let exception = Exception(name: name, newSections: data.sections, oldSections: previousSections, changes: changes, visible: visibleIndexPaths, viewFrame: tableView?.frame ?? .zero, reason: exceptionReason, userInfo: exceptionUserInfo)
 		exceptionHandler.handle(exception: exception)
 	}
 	
-	var sections: [TableSection] {
-		get {
-			return dataSource.sections
-		}
-		set {
-			cellStyler.sections = newValue
-			dataSource.sections = newValue
-			delegate.sections = newValue
+	private var data: TableData {
+		didSet {
+			cellStyler.data = data
+			dataSource.data = data
+			delegate.data = data
 		}
 	}
+
 	private static let reloadEntireTableThreshold = 20
 	
 	private let renderAndDiffQueue: OperationQueue
@@ -80,7 +78,7 @@ public class FunctionalTableData {
 	}
 	
 	public subscript(indexPath: IndexPath) -> CellConfigType? {
-		return sections[indexPath]
+		return data.sections[indexPath]
 	}
 	
 	/// An object to receive various [UIScrollViewDelegate](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate) related events
@@ -139,8 +137,9 @@ public class FunctionalTableData {
 		renderAndDiffQueue = OperationQueue()
 		renderAndDiffQueue.name = self.name
 		renderAndDiffQueue.maxConcurrentOperationCount = 1
-		
-		let cellStyler = CellStyler()
+		let data = TableData()
+		let cellStyler = CellStyler(data: data)
+		self.data = data
 		self.cellStyler = cellStyler
 		self.dataSource = DataSource(cellStyler: cellStyler)
 		self.delegate = Delegate(cellStyler: cellStyler)
@@ -155,8 +154,8 @@ public class FunctionalTableData {
 	/// - Parameter keyPath: A key path identifying the cell to look up.
 	/// - Returns: A `CellConfigType` instance corresponding to the key path or `nil` if the key path is invalid.
 	public func rowForKeyPath(_ keyPath: ItemPath) -> CellConfigType? {
-		if let sectionIndex = sections.firstIndex(where: { $0.key == keyPath.sectionKey }), let rowIndex = sections[sectionIndex].rows.firstIndex(where: { $0.key == keyPath.itemKey }) {
-			return sections[sectionIndex].rows[rowIndex]
+		if let sectionIndex = data.sections.firstIndex(where: { $0.key == keyPath.sectionKey }), let rowIndex = data.sections[sectionIndex].rows.firstIndex(where: { $0.key == keyPath.itemKey }) {
+			return data.sections[sectionIndex].rows[rowIndex]
 		}
 		
 		return nil
@@ -167,7 +166,7 @@ public class FunctionalTableData {
 	/// - Parameter key: String identifier to lookup.
 	/// - Returns: A `ItemPath` that matches the key or `nil` if there is no match.
 	public func keyPathForRowKey(_ key: String) -> ItemPath? {
-		for section in sections {
+		for section in data.sections {
 			for row in section where row.key == key {
 				return ItemPath(sectionKey: section.key, itemKey: row.key)
 			}
@@ -183,7 +182,7 @@ public class FunctionalTableData {
 	/// - Parameter indexPath: A key path identifying where the key path is located.
 	/// - Returns: The key representation of the supplied `IndexPath`.
 	public func keyPathForIndexPath(indexPath: IndexPath) -> ItemPath {
-		let section = sections[indexPath.section]
+		let section = data.sections[indexPath.section]
 		let row = section.rows[indexPath.row]
 		return ItemPath(sectionKey: section.key, itemKey: row.key)
 	}
@@ -246,7 +245,7 @@ public class FunctionalTableData {
 						guard let exceptionHandler = FunctionalTableData.exceptionHandler else { return }
 						let changes = TableSectionChangeSet()
 						let viewFrame = DispatchQueue.main.sync { strongSelf.tableView?.frame ?? .zero }
-						let exception = Exception(name: $0.name.rawValue, newSections: newSections, oldSections: strongSelf.sections, changes: changes, visible: [], viewFrame: viewFrame, reason: $0.reason, userInfo: $0.userInfo)
+						let exception = Exception(name: $0.name.rawValue, newSections: newSections, oldSections: strongSelf.data.sections, changes: changes, visible: [], viewFrame: viewFrame, reason: $0.reason, userInfo: $0.userInfo)
 						exceptionHandler.handle(exception: exception)
 					}
 				})
@@ -267,7 +266,7 @@ public class FunctionalTableData {
 			return
 		}
 		
-		let oldSections = sections
+		let oldSections = data.sections
 		
 		let visibleIndexPaths = DispatchQueue.main.sync {
 			tableView.indexPathsForVisibleRows?.filter {
@@ -290,7 +289,7 @@ public class FunctionalTableData {
 			strongSelf.renderAndDiffQueue.isSuspended = true
 			tableView.registerCellsForSections(localSections)
 			if oldSections.isEmpty || changes.count > FunctionalTableData.reloadEntireTableThreshold || tableView.isDecelerating || !animated {
-				strongSelf.sections = localSections
+				strongSelf.data.sections = localSections
 				CATransaction.begin()
 				CATransaction.setCompletionBlock {
 					strongSelf.finishRenderAndDiff()
@@ -329,7 +328,7 @@ public class FunctionalTableData {
 		}
 		
 		if changes.isEmpty {
-			sections = localSections
+			data.sections = localSections
 			if let completion = completion {
 				DispatchQueue.main.async(execute: completion)
 			}
@@ -378,7 +377,7 @@ public class FunctionalTableData {
 		tableView.beginUpdates()
 		// #4629 - There is an issue where on some occasions calling beginUpdates() will cause a heightForRowAtIndexPath() call to be made. If the sections have been changed already we may no longer find the cells
 		// in the model causing a crash. To prevent this from happening, only load the new model AFTER beginUpdates() has run
-		sections = localSections
+		data.sections = localSections
 		applyTableSectionChanges(changes)
 		tableView.endUpdates()
 		
@@ -447,7 +446,7 @@ public class FunctionalTableData {
 	}
 	
 	public func indexPathFromKeyPath(_ keyPath: ItemPath) -> IndexPath? {
-		return sections.indexPath(from: keyPath)
+		return data.sections.indexPath(from: keyPath)
 	}
 	
 	internal func calculateTableChanges(oldSections: [TableSection], newSections: [TableSection], visibleIndexPaths: [IndexPath]) -> TableSectionChangeSet {

--- a/FunctionalTableData/TableView/FunctionalTableData.swift
+++ b/FunctionalTableData/TableView/FunctionalTableData.swift
@@ -45,11 +45,14 @@ public class FunctionalTableData {
 		exceptionHandler.handle(exception: exception)
 	}
 	
-	private var sections: [TableSection] = [] {
-		didSet {
-			cellStyler.sections = sections
-			dataSource.sections = sections
-			delegate.sections = sections
+	var sections: [TableSection] {
+		get {
+			return dataSource.sections
+		}
+		set {
+			cellStyler.sections = newValue
+			dataSource.sections = newValue
+			delegate.sections = newValue
 		}
 	}
 	private static let reloadEntireTableThreshold = 20

--- a/FunctionalTableData/TableView/FunctionalTableData.swift
+++ b/FunctionalTableData/TableView/FunctionalTableData.swift
@@ -45,14 +45,7 @@ public class FunctionalTableData {
 		exceptionHandler.handle(exception: exception)
 	}
 	
-	private var data: TableData {
-		didSet {
-			cellStyler.data = data
-			dataSource.data = data
-			delegate.data = data
-		}
-	}
-
+	private let data: TableData
 	private static let reloadEntireTableThreshold = 20
 	
 	private let renderAndDiffQueue: OperationQueue

--- a/FunctionalTableDataDemo/View Controllers/TableExampleController.swift
+++ b/FunctionalTableDataDemo/View Controllers/TableExampleController.swift
@@ -11,28 +11,25 @@ import FunctionalTableData
 
 class TableExampleController: UITableViewController {
 	private let functionalData = FunctionalTableData()
-	private var items: [String] = [] {
-		didSet {
-			render()
-		}
-	}
+	private var items: [String] = []
 	
 	override func viewDidLoad() {
 		super.viewDidLoad()
-		
+		tableView.isEditing = true
 		functionalData.tableView = tableView
 		title = "Table View"
 		navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .add, target: self, action: #selector(didSelectAdd))
 	}
 	
 	@objc private func didSelectAdd() {
-		items.append(NSDate().description)
+		items.append("\(items.count)")
+		render()
 	}
 	
 	private func render() {
 		let rows: [CellConfigType] = items.enumerated().map { index, item in
 			return LabelCell(
-				key: "id-\(index)",
+				key: "id-\(item)",
 				actions: CellActions(
 					selectionAction: { _ in
 						print("\(item) selected")
@@ -41,13 +38,20 @@ class TableExampleController: UITableViewController {
 					deselectionAction: { _ in
 						print("\(item) deselected")
 						return .deselected
-				}),
+				},
+					canBeMoved: true
+				),
 				state: LabelState(text: item),
 				cellUpdater: LabelState.updateView)
 		}
 		
 		functionalData.renderAndDiff([
-			TableSection(key: "section", rows: rows)
+			TableSection(key: "section", rows: rows) { [ weak self] (from, to) in
+				if let cell = self?.items.remove(at: from) {
+					self?.items.insert(cell, at: to)
+					self?.render()
+				}
+			}
         ])
 	}
 }

--- a/FunctionalTableDataDemo/View Controllers/TableExampleController.swift
+++ b/FunctionalTableDataDemo/View Controllers/TableExampleController.swift
@@ -11,25 +11,28 @@ import FunctionalTableData
 
 class TableExampleController: UITableViewController {
 	private let functionalData = FunctionalTableData()
-	private var items: [String] = []
+	private var items: [String] = [] {
+		didSet {
+			render()
+		}
+	}
 	
 	override func viewDidLoad() {
 		super.viewDidLoad()
-		tableView.isEditing = true
+		
 		functionalData.tableView = tableView
 		title = "Table View"
 		navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .add, target: self, action: #selector(didSelectAdd))
 	}
 	
 	@objc private func didSelectAdd() {
-		items.append("\(items.count)")
-		render()
+		items.append(NSDate().description)
 	}
 	
 	private func render() {
 		let rows: [CellConfigType] = items.enumerated().map { index, item in
 			return LabelCell(
-				key: "id-\(item)",
+				key: "id-\(index)",
 				actions: CellActions(
 					selectionAction: { _ in
 						print("\(item) selected")
@@ -38,20 +41,13 @@ class TableExampleController: UITableViewController {
 					deselectionAction: { _ in
 						print("\(item) deselected")
 						return .deselected
-				},
-					canBeMoved: true
-				),
+				}),
 				state: LabelState(text: item),
 				cellUpdater: LabelState.updateView)
 		}
 		
 		functionalData.renderAndDiff([
-			TableSection(key: "section", rows: rows) { [ weak self] (from, to) in
-				if let cell = self?.items.remove(at: from) {
-					self?.items.insert(cell, at: to)
-					self?.render()
-				}
-			}
+			TableSection(key: "section", rows: rows)
         ])
 	}
 }

--- a/FunctionalTableDataTests/FunctionalTableDataDelegateTests.swift
+++ b/FunctionalTableDataTests/FunctionalTableDataDelegateTests.swift
@@ -26,8 +26,13 @@ class FunctionalTableDataDelegateTests: XCTestCase {
 			)
 		)
 		let cell = HostCell<UIView, String, LayoutMarginsTableItemLayout>(key: "actions", actions: actions, state: "Actions") { (_, _) in }
-		let delegate = FunctionalTableData.Delegate(cellStyler: FunctionalTableData.CellStyler())
-		delegate.sections = [TableSection(key: "Section", rows: [cell])]
+		let data = FunctionalTableData.TableData()
+		data.sections = [TableSection(key: "Section", rows: [cell])]
+		let delegate = FunctionalTableData.Delegate(
+			cellStyler: FunctionalTableData.CellStyler(
+				data: data
+			)
+		)
 		let indexPath = IndexPath(row: 0, section: 0)
 		
 		let rowActions = delegate.tableView(tableView, editActionsForRowAt: indexPath)


### PR DESCRIPTION
In the current implementation, when the user manually moves a row `tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath)` will modify the datasource `sections` but not the `sections` of `FunctionalTableData`. 

If the TableSection `didMoveRow` calls for a re-render then `FunctionalTableData` will detect changes. If the changes detected are "move" changes in an animated render, another unexpected move could be applied on top of the current one
