### PR TITLE
Making TableData a type used across both tables and collections

### DIFF
--- a/FunctionalTableData.xcodeproj/project.pbxproj
+++ b/FunctionalTableData.xcodeproj/project.pbxproj
@@ -63,7 +63,7 @@
 		6C5F34C92232E8D300D57BEA /* FunctionalCollectionData+UICollectionViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C5F34C82232E8D300D57BEA /* FunctionalCollectionData+UICollectionViewDelegate.swift */; };
 		6C5F34CB2232E99000D57BEA /* FunctionalCollectionData+UICollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C5F34CA2232E99000D57BEA /* FunctionalCollectionData+UICollectionViewDataSource.swift */; };
 		6C910BA922529B390000D7E9 /* FunctionalTableDataDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C910BA822529B390000D7E9 /* FunctionalTableDataDelegateTests.swift */; };
-		8F3A07AB2277999D00BBA836 /* FunctionalTableData+Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F3A07AA2277999D00BBA836 /* FunctionalTableData+Data.swift */; };
+		8F3A07AB2277999D00BBA836 /* TableData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F3A07AA2277999D00BBA836 /* TableData.swift */; };
 		9FF97DB3212CA23B006FA047 /* TableCellReuseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FF97DB2212CA23B006FA047 /* TableCellReuseTests.swift */; };
 		BC8C5D4121763B7B00443E28 /* BackgroundViewProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC8C5D4021763B7B00443E28 /* BackgroundViewProvider.swift */; };
 /* End PBXBuildFile section */
@@ -159,7 +159,7 @@
 		6C5F34C82232E8D300D57BEA /* FunctionalCollectionData+UICollectionViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FunctionalCollectionData+UICollectionViewDelegate.swift"; sourceTree = "<group>"; };
 		6C5F34CA2232E99000D57BEA /* FunctionalCollectionData+UICollectionViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FunctionalCollectionData+UICollectionViewDataSource.swift"; sourceTree = "<group>"; };
 		6C910BA822529B390000D7E9 /* FunctionalTableDataDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunctionalTableDataDelegateTests.swift; sourceTree = "<group>"; };
-		8F3A07AA2277999D00BBA836 /* FunctionalTableData+Data.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FunctionalTableData+Data.swift"; sourceTree = "<group>"; };
+		8F3A07AA2277999D00BBA836 /* TableData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableData.swift; sourceTree = "<group>"; };
 		9FF97DB2212CA23B006FA047 /* TableCellReuseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableCellReuseTests.swift; sourceTree = "<group>"; };
 		BC8C5D4021763B7B00443E28 /* BackgroundViewProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundViewProvider.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -310,6 +310,7 @@
 		4C7A27161F2FA10A00360E9B /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				8F3A07AA2277999D00BBA836 /* TableData.swift */,
 				BC8C5D4021763B7B00443E28 /* BackgroundViewProvider.swift */,
 				4C7A276F1F2FB55D00360E9B /* CellActions.swift */,
 				4C7A27701F2FB55D00360E9B /* CellConfigType.swift */,
@@ -347,9 +348,9 @@
 				4CCCE83F1F8AA7B200C73258 /* CollectionCell.swift */,
 				4CCCE8421F8AA7B200C73258 /* CollectionItemConfigType.swift */,
 				4CCCE8411F8AA7B200C73258 /* FunctionalCollectionData.swift */,
+				6C5F34CA2232E99000D57BEA /* FunctionalCollectionData+UICollectionViewDataSource.swift */,
 				6C5F34C82232E8D300D57BEA /* FunctionalCollectionData+UICollectionViewDelegate.swift */,
 				4CCCE8401F8AA7B200C73258 /* UICollectionView+Reusable.swift */,
-				6C5F34CA2232E99000D57BEA /* FunctionalCollectionData+UICollectionViewDataSource.swift */,
 			);
 			path = CollectionView;
 			sourceTree = "<group>";
@@ -358,7 +359,6 @@
 			isa = PBXGroup;
 			children = (
 				4C7A27711F2FB55D00360E9B /* FunctionalTableData.swift */,
-				8F3A07AA2277999D00BBA836 /* FunctionalTableData+Data.swift */,
 				6C507AF52249268900D04521 /* FunctionalTableData+Cells.swift */,
 				6C5F34C62232D15500D57BEA /* FunctionalTableData+UITableViewDataSource.swift */,
 				6C5F34C42232D14B00D57BEA /* FunctionalTableData+UITableViewDelegate.swift */,
@@ -579,7 +579,7 @@
 				6C5F34CB2232E99000D57BEA /* FunctionalCollectionData+UICollectionViewDataSource.swift in Sources */,
 				4C7A27801F2FB55D00360E9B /* Reusable.swift in Sources */,
 				4C63250D1F8AA8A000B2B74B /* UITableView+Reusable.swift in Sources */,
-				8F3A07AB2277999D00BBA836 /* FunctionalTableData+Data.swift in Sources */,
+				8F3A07AB2277999D00BBA836 /* TableData.swift in Sources */,
 				4C7A277B1F2FB55D00360E9B /* CellActions.swift in Sources */,
 				4C6325131F8AA8A400B2B74B /* FunctionalCollectionData.swift in Sources */,
 				3624340420D2F40100A75787 /* Array+TableSection.swift in Sources */,

--- a/FunctionalTableData/CollectionView/FunctionalCollectionData+UICollectionViewDataSource.swift
+++ b/FunctionalTableData/CollectionView/FunctionalCollectionData+UICollectionViewDataSource.swift
@@ -10,18 +10,22 @@ import Foundation
 
 extension FunctionalCollectionData {
 	class DataSource: NSObject, UICollectionViewDataSource {
-		var sections: [TableSection] = []
+		private let data: TableData
+		
+		init(data: TableData) {
+			self.data = data
+		}
 		
 		public func numberOfSections(in collectionView: UICollectionView) -> Int {
-			return sections.count
+			return data.sections.count
 		}
 		
 		public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-			return sections[section].rows.count
+			return data.sections[section].rows.count
 		}
 		
 		public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-			let sectionData = sections[indexPath.section]
+			let sectionData = data.sections[indexPath.section]
 			let row = indexPath.item
 			let cellConfig = sectionData[row]
 			let cell = cellConfig.dequeueCell(from: collectionView, at: indexPath)
@@ -38,14 +42,14 @@ extension FunctionalCollectionData {
 			assert(sourceIndexPath.section == destinationIndexPath.section)
 			
 			// Update internal state to match move
-			let cell = sections[sourceIndexPath.section].rows.remove(at: sourceIndexPath.item)
-			sections[destinationIndexPath.section].rows.insert(cell, at: destinationIndexPath.item)
+			let cell = data.sections[sourceIndexPath.section].rows.remove(at: sourceIndexPath.item)
+			data.sections[destinationIndexPath.section].rows.insert(cell, at: destinationIndexPath.item)
 			
-			sections[sourceIndexPath.section].didMoveRow?(sourceIndexPath.item, destinationIndexPath.item)
+			data.sections[sourceIndexPath.section].didMoveRow?(sourceIndexPath.item, destinationIndexPath.item)
 		}
 		
 		public func collectionView(_ collectionView: UICollectionView, canMoveItemAt indexPath: IndexPath) -> Bool {
-			return sections[indexPath]?.actions.canBeMoved ?? false
+			return data.sections[indexPath]?.actions.canBeMoved ?? false
 		}
 	}
 }

--- a/FunctionalTableData/CollectionView/FunctionalCollectionData+UICollectionViewDelegate.swift
+++ b/FunctionalTableData/CollectionView/FunctionalCollectionData+UICollectionViewDelegate.swift
@@ -10,10 +10,14 @@ import Foundation
 
 extension FunctionalCollectionData {
 	class Delegate: NSObject, UICollectionViewDelegate {
-		var sections: [TableSection] = []
-		
 		weak var scrollViewDelegate: UIScrollViewDelegate?
 		var backwardsCompatScrollViewDelegate = ScrollViewDelegate()
+		
+		private let data: TableData
+		
+		init(data: TableData) {
+			self.data = data
+		}
 		
 		public override func responds(to aSelector: Selector!) -> Bool {
 			if class_respondsToSelector(type(of: self), aSelector) {
@@ -43,12 +47,12 @@ extension FunctionalCollectionData {
 		}
 		
 		public func collectionView(_ collectionView: UICollectionView, shouldHighlightItemAt indexPath: IndexPath) -> Bool {
-			return sections[indexPath]?.actions.selectionAction != nil
+			return data.sections[indexPath]?.actions.selectionAction != nil
 		}
 		
 		public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
 			guard let cell = collectionView.cellForItem(at: indexPath) else { return }
-			let cellConfig = sections[indexPath]
+			let cellConfig = data.sections[indexPath]
 			
 			let selectionState = cellConfig?.actions.selectionAction?(cell) ?? .deselected
 			if selectionState == .deselected {
@@ -60,7 +64,7 @@ extension FunctionalCollectionData {
 		
 		public func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
 			guard let cell = collectionView.cellForItem(at: indexPath) else { return }
-			let cellConfig = sections[indexPath]
+			let cellConfig = data.sections[indexPath]
 			
 			let selectionState = cellConfig?.actions.deselectionAction?(cell) ?? .deselected
 			if selectionState == .selected {
@@ -71,27 +75,27 @@ extension FunctionalCollectionData {
 		}
 		
 		public func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
-			guard indexPath.section < sections.count else { return }
+			guard indexPath.section < data.sections.count else { return }
 			
-			if let cellConfig = sections[indexPath] {
+			if let cellConfig = data.sections[indexPath] {
 				cellConfig.actions.visibilityAction?(cell, true)
 				return
 			}
 		}
 		
 		public func collectionView(_ collectionView: UICollectionView, didEndDisplaying cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
-			if let cellConfig = sections[indexPath] {
+			if let cellConfig = data.sections[indexPath] {
 				cellConfig.actions.visibilityAction?(cell, false)
 				return
 			}
 		}
 		
 		public func collectionView(_ collectionView: UICollectionView, shouldShowMenuForItemAt indexPath: IndexPath) -> Bool {
-			return sections[indexPath]?.actions.canPerformAction != nil
+			return data.sections[indexPath]?.actions.canPerformAction != nil
 		}
 		
 		public func collectionView(_ collectionView: UICollectionView, canPerformAction action: Selector, forItemAt indexPath: IndexPath, withSender sender: Any?) -> Bool {
-			return sections[indexPath]?.actions.canPerformAction?(action) ?? false
+			return data.sections[indexPath]?.actions.canPerformAction?(action) ?? false
 		}
 		
 		public func collectionView(_ collectionView: UICollectionView, performAction action: Selector, forItemAt indexPath: IndexPath, withSender sender: Any?) {

--- a/FunctionalTableData/TableData.swift
+++ b/FunctionalTableData/TableData.swift
@@ -1,5 +1,5 @@
 //
-//  FunctionalTableData+Data.swift
+//  TableData.swift
 //  FunctionalTableData
 //
 //  Created by Pierre Oleo on 2019-04-29.
@@ -7,8 +7,7 @@
 //
 
 import Foundation
-extension FunctionalTableData {
-	class TableData {
-		var sections: [TableSection] = []
-	}
+
+class TableData {
+	var sections: [TableSection] = []
 }

--- a/FunctionalTableDataTests/FunctionalTableDataDelegateTests.swift
+++ b/FunctionalTableDataTests/FunctionalTableDataDelegateTests.swift
@@ -26,7 +26,7 @@ class FunctionalTableDataDelegateTests: XCTestCase {
 			)
 		)
 		let cell = HostCell<UIView, String, LayoutMarginsTableItemLayout>(key: "actions", actions: actions, state: "Actions") { (_, _) in }
-		let data = FunctionalTableData.TableData()
+		let data = TableData()
 		data.sections = [TableSection(key: "Section", rows: [cell])]
 		let delegate = FunctionalTableData.Delegate(
 			cellStyler: FunctionalTableData.CellStyler(


### PR DESCRIPTION
This one is just a code shuffle, making the new TableData type useable by FunctionalCollectionData as well (also did a `strongSelf` rename to just `self`)