### PR TITLE
Separator customization

### DIFF
--- a/FunctionalTableData/Separator.swift
+++ b/FunctionalTableData/Separator.swift
@@ -47,11 +47,11 @@ public class Separator: UIView {
 		/// - Parameters:
 		///   - leadingInset: The spacing to use from the leading edge.
 		///   - trailingInset: The spacing to use from the trailing edge.
-		///   - thickness: The thickness in pixels of the separator. The screen scale is automatically applied to this value.
-		public init(leadingInset: Inset, trailingInset: Inset, thickness: CGFloat = 1.0) {
+		///   - thickness: The thickness of the separator.
+		public init(leadingInset: Inset, trailingInset: Inset, thickness: CGFloat = 1.0 / UIScreen.main.scale) {
 			self.leadingInset = leadingInset
 			self.trailingInset = trailingInset
-			self.thickness = thickness / UIScreen.main.scale
+			self.thickness = thickness
 		}
 	}
 	

--- a/FunctionalTableData/Separator.swift
+++ b/FunctionalTableData/Separator.swift
@@ -18,11 +18,11 @@ public class Separator: UIView {
 	public struct Style: Equatable {
 		/// The inset used in the separators.
 		public struct Inset: Equatable {
-			/// Specifies the amount of spacing to apply to the separator
+			/// Specifies the amount of spacing to apply to the separator.
 			public let value: CGFloat
 			/// Specifies if the inset is relative to the layout margins.
 			public let respectingLayoutMargins: Bool
-			
+
 			public static let none: Inset = Inset(value: 0, respectingLayoutMargins: false)
 			
 			public init(value: CGFloat, respectingLayoutMargins: Bool) {
@@ -37,10 +37,17 @@ public class Separator: UIView {
 		public let trailingInset: Inset
 		/// Specifies the thickness of cell separators.
 		public let thickness: CGFloat
-		
+		/// A separator going from the leading edge to the trailing edge of the screen.
 		static public let full: Style = Style(leadingInset: .none, trailingInset: .none)
+		/// A separator going from the leading margin to the trailing edge of the screen.
 		static public let inset: Style = Style(leadingInset: .init(value: 0, respectingLayoutMargins: true), trailingInset: .none)
 		
+		/// Initializes and returns a newly separator style.
+		///
+		/// - Parameters:
+		///   - leadingInset: The spacing to use from the leading edge.
+		///   - trailingInset: The spacing to use from the trailing edge.
+		///   - thickness: The thickness in pixels of the separator. The screen scale is automatically applied to this value.
 		public init(leadingInset: Inset, trailingInset: Inset, thickness: CGFloat = 1.0) {
 			self.leadingInset = leadingInset
 			self.trailingInset = trailingInset

--- a/FunctionalTableDataTests/CellStyleTests.swift
+++ b/FunctionalTableDataTests/CellStyleTests.swift
@@ -58,17 +58,20 @@ class StyleTests: XCTestCase {
 		XCTAssertNotNil(separator)
 		XCTAssertEqual(separator!.bounds.width, cell.bounds.width - cell.layoutMarginsGuide.layoutFrame.minX)
 		
-		style.bottomSeparator = .moreInset
-		style.configure(cell: cell, in: table)
-		separator = cell.viewWithTag(Separator.Tag.bottom.rawValue)
-		cell.layoutIfNeeded()
-		XCTAssertNotNil(separator)
-		XCTAssertEqual(separator!.bounds.width, cell.bounds.width - 3 * Separator.inset)
-		
 		style.bottomSeparator = nil
 		style.configure(cell: cell, in: table)
 		separator = cell.viewWithTag(Separator.Tag.bottom.rawValue)
 		XCTAssertNil(separator)
+	}
+	
+	func testCustomBottomSeparator() {
+		style.bottomSeparator = Separator.Style(leadingInset: .init(value: 10, respectingLayoutMargins: false), trailingInset: .none, thickness: 20)
+		style.configure(cell: cell, in: table)
+		let separator = cell.viewWithTag(Separator.Tag.bottom.rawValue)
+		cell.layoutIfNeeded()
+		XCTAssertNotNil(separator)
+		XCTAssertEqual(separator!.bounds.width, cell.bounds.width - 10)
+		XCTAssertEqual(separator!.bounds.height, 20 / UIScreen.main.scale)
 	}
 	
 	func testTopSeparator() {
@@ -86,17 +89,20 @@ class StyleTests: XCTestCase {
 		XCTAssertNotNil(separator)
 		XCTAssertEqual(separator!.bounds.width, cell.bounds.width - cell.layoutMarginsGuide.layoutFrame.minX)
 		
-		style.topSeparator = .moreInset
-		style.configure(cell: cell, in: table)
-		separator = cell.viewWithTag(Separator.Tag.top.rawValue)
-		cell.layoutIfNeeded()
-		XCTAssertNotNil(separator)
-		XCTAssertEqual(separator!.bounds.width, cell.bounds.width - 3 * Separator.inset)
-		
 		style.topSeparator = nil
 		style.configure(cell: cell, in: table)
 		separator = cell.viewWithTag(Separator.Tag.top.rawValue)
 		XCTAssertNil(separator)
+	}
+	
+	func testCustomTopSeparator() {
+		style.topSeparator = Separator.Style(leadingInset: .init(value: 10, respectingLayoutMargins: false), trailingInset: .none, thickness: 20)
+		style.configure(cell: cell, in: table)
+		let separator = cell.viewWithTag(Separator.Tag.top.rawValue)
+		cell.layoutIfNeeded()
+		XCTAssertNotNil(separator)
+		XCTAssertEqual(separator!.bounds.width, cell.bounds.width - 10)
+		XCTAssertEqual(separator!.bounds.height, 20 / UIScreen.main.scale)
 	}
 	
 	func testHighlight() {

--- a/FunctionalTableDataTests/CellStyleTests.swift
+++ b/FunctionalTableDataTests/CellStyleTests.swift
@@ -71,7 +71,7 @@ class StyleTests: XCTestCase {
 		cell.layoutIfNeeded()
 		XCTAssertNotNil(separator)
 		XCTAssertEqual(separator!.bounds.width, cell.bounds.width - 10)
-		XCTAssertEqual(separator!.bounds.height, 20 / UIScreen.main.scale)
+		XCTAssertEqual(separator!.bounds.height, 20)
 	}
 	
 	func testTopSeparator() {
@@ -102,7 +102,7 @@ class StyleTests: XCTestCase {
 		cell.layoutIfNeeded()
 		XCTAssertNotNil(separator)
 		XCTAssertEqual(separator!.bounds.width, cell.bounds.width - 10)
-		XCTAssertEqual(separator!.bounds.height, 20 / UIScreen.main.scale)
+		XCTAssertEqual(separator!.bounds.height, 20)
 	}
 	
 	func testHighlight() {


### PR DESCRIPTION
## What

This PR allows for more control over the separator in FunctionalTableData. This will be a breaking change for anyone using `.custom`. But it's safe for `.inset` and `.full`.

The demo project shouldn't visually change, and the tests have been modified to account for the new styling.