### PR TITLE
Allow cells to be unhighlighted

### DIFF
--- a/FunctionalTableData/TableView/FunctionalTableData+Cells.swift
+++ b/FunctionalTableData/TableView/FunctionalTableData+Cells.swift
@@ -17,6 +17,12 @@ extension FunctionalTableData {
 			self.data = data
 		}
 		
+		/// Highlights the cell at `itemPath`, or removes highlighting if `itemPath` is nil
+		///
+		/// - Parameters:
+		///   - itemPath: The path of the item to highlight
+		///   - animated: Indicates if the highlight should be animated or not
+		///   - tableView: The table view containing the cell to highlight
 		func highlightRow(at itemPath: ItemPath?, animated: Bool, in tableView: UITableView) {
 			if let highlightedRow = highlightedRow, let currentlyHighlightedIndexPath = data.sections.indexPath(from: highlightedRow), let currentlyHighlightedCell = tableView.cellForRow(at: currentlyHighlightedIndexPath) {
 				currentlyHighlightedCell.setHighlighted(false, animated: animated)

--- a/FunctionalTableData/TableView/FunctionalTableData+UITableViewDelegate.swift
+++ b/FunctionalTableData/TableView/FunctionalTableData+UITableViewDelegate.swift
@@ -93,6 +93,7 @@ extension FunctionalTableData {
 				return nil
 			}
 			
+			let highlightRow = cellStyler.highlightedRow
 			let keyPath = data.sections.itemPath(from: indexPath)
 			
 			if let canSelectAction = cellConfig.actions.canSelectAction {
@@ -105,7 +106,7 @@ extension FunctionalTableData {
 						self.tableView(tableView, didSelectRowAt: indexPath)
 						NotificationCenter.default.post(name: UITableView.selectionDidChangeNotification, object: tableView)
 					} else {
-						self.cellStyler.highlightRow(at: keyPath, animated: false, in: tableView)
+						self.cellStyler.highlightRow(at: highlightRow, animated: false, in: tableView)
 					}
 				}
 				DispatchQueue.main.async {

--- a/FunctionalTableDataDemo/View Controllers/TableExampleController.swift
+++ b/FunctionalTableDataDemo/View Controllers/TableExampleController.swift
@@ -28,6 +28,8 @@ class TableExampleController: UITableViewController {
 			networkSection(key: "network.section"),
 			spacerSection(key: "spacer.network"),
 			resetSection(key: "reset.section"),
+			spacerSection(key: "spacer.reset"),
+			highlightSection(key: "highlight.section"),
 		])
 	}
 	
@@ -96,6 +98,43 @@ class TableExampleController: UITableViewController {
 		let rows: [CellConfigType] = [
 			ButtonCell(key: "all.settings", state: ButtonState(title: "Reset All Settings", alignment: .left, action: { _ in }), cellUpdater: ButtonState.updateView),
 			ButtonCell(key: "all.content.settings", state: ButtonState(title: "Reset All Content and Settings", alignment: .left, action: { _ in }), cellUpdater: ButtonState.updateView),
+		]
+		return TableSection(key: key, rows: rows, style: SectionStyle(separators: .default))
+	}
+	
+	private func highlightSection(key: String) -> TableSection {
+		func confirmSelection(_ callback: @escaping (Bool) -> Void) {
+			let alert = UIAlertController(title: "Confirm selection", message: "Please confirm that you want to change the current selection", preferredStyle: .alert)
+			alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: { _ in
+				callback(false)
+			}))
+			alert.addAction(UIAlertAction(title: "Confirm", style: .default, handler: { _ in
+				callback(true)
+			}))
+			present(alert, animated: true)
+		}
+		
+		func cellActions(key: String) -> CellActions {
+			return CellActions(
+				canSelectAction: { canSelectCallback in confirmSelection(canSelectCallback) },
+				selectionAction: { sender in return .selected },
+				deselectionAction: { sender in return .deselected }
+			)
+		}
+		
+		func labelCell(key: String, label: String) -> LabelCell {
+			return LabelCell(
+				key: key,
+				style: CellStyle(highlight: true),
+				actions: cellActions(key: key),
+				state: LabelState(text: .plain(label), font: UIFont.systemFont(ofSize: 16)),
+				cellUpdater: LabelState.updateView
+			)
+		}
+		let rows = [
+			labelCell(key: "highlight.cell.1", label: "Selectable Cell 1"),
+			labelCell(key: "highlight.cell.2", label: "Selectable Cell 2"),
+			labelCell(key: "highlight.cell.3", label: "Selectable Cell 3")
 		]
 		return TableSection(key: key, rows: rows, style: SectionStyle(separators: .default))
 	}


### PR DESCRIPTION
When using CanSelectAction you should be able to cancel the selection and have the highlight cell revert to the previous one or none if nothing was selected. The code currently highlights the cell even if you cancel the selection. 

This PR saves the original highlight cell and sets it to be highlighted again if the selection is cancelled.