### PR TITLE
Remove highlight when selection action returns .deselect

### DIFF
--- a/FunctionalTableData/TableView/FunctionalTableData+UITableViewDelegate.swift
+++ b/FunctionalTableData/TableView/FunctionalTableData+UITableViewDelegate.swift
@@ -127,6 +127,7 @@ extension FunctionalTableData {
 			if selectionState == .deselected {
 				DispatchQueue.main.async {
 					tableView.deselectRow(at: indexPath, animated: true)
+					self.cellStyler.highlightRow(at: nil, animated: false, in: tableView)
 				}
 			}
 		}


### PR DESCRIPTION
When the SelectAction returns .deselect the delegate should be unhightlighting as well as deselecting.