### PR TITLE
Remove deinit

### DIFF
--- a/FunctionalTableData/CollectionView/FunctionalCollectionData.swift
+++ b/FunctionalTableData/CollectionView/FunctionalCollectionData.swift
@@ -87,10 +87,6 @@ public class FunctionalCollectionData {
 		self.delegate = Delegate(data: data)
 	}
 	
-	deinit {
-		collectionView?.delegate = nil
-	}
-	
 	/// Returns the cell identified by a key path.
 	///
 	/// - Parameter keyPath: A key path identifying the cell to look up.

--- a/FunctionalTableData/TableView/FunctionalTableData.swift
+++ b/FunctionalTableData/TableView/FunctionalTableData.swift
@@ -138,10 +138,6 @@ public class FunctionalTableData {
 		self.delegate = Delegate(cellStyler: cellStyler)
 	}
 	
-	deinit {
-		tableView?.delegate = nil
-	}
-	
 	/// Returns the cell identified by a key path.
 	///
 	/// - Parameter keyPath: A key path identifying the cell to look up.


### PR DESCRIPTION
Clearing the delegate isn't necessary and can cause a crash at dev time if the FTD or CTD gets deinitialized off of the main thread. So far I've only seen this happen while running unit tests, but it happens.