### PR TITLE
Add delaysContentTouches to CellStyle

### DIFF
--- a/FunctionalTableData/CellStyle.swift
+++ b/FunctionalTableData/CellStyle.swift
@@ -65,6 +65,10 @@ public struct CellStyle {
 	public var layoutMargins: UIEdgeInsets?
 	/// The radius to use when drawing rounded corners in the view.
 	public var cornerRadius: CGFloat
+	/// Whether touch-down gestures on the cell should be delayed.
+	///
+	/// Supported by `UITableView` only.
+	public var delaysContentTouches: Bool?
 	
 	@available(*, deprecated, message: "The `backgroundView` argument is no longer available. Use backgroundViewProvider instead.")
 	public init(topSeparator: Separator.Style? = nil,
@@ -114,7 +118,8 @@ public struct CellStyle {
 				backgroundViewProvider: BackgroundViewProvider? = nil,
 				tintColor: UIColor? = nil,
 				layoutMargins: UIEdgeInsets? = nil,
-				cornerRadius: CGFloat = 0) {
+				cornerRadius: CGFloat = 0,
+				delaysContentTouches: Bool? = nil) {
 		self.bottomSeparator = bottomSeparator
 		self.topSeparator = topSeparator
 		self.separatorColor = separatorColor
@@ -126,6 +131,7 @@ public struct CellStyle {
 		self.tintColor = tintColor
 		self.layoutMargins = layoutMargins
 		self.cornerRadius = cornerRadius
+		self.delaysContentTouches = delaysContentTouches
 	}
 	
 	func configure(cell: UICollectionViewCell, in collectionView: UICollectionView) {
@@ -192,6 +198,14 @@ public struct CellStyle {
 		}
 		
 		cell.accessoryType = accessoryType
+		
+		// On iOS 7+, setting delaysContentTouches on the table view is no longer enough, each UITableViewCell has its own UIScrollView which needs to be treated.
+		// https://stackoverflow.com/a/22925576
+		if let delaysContentTouches = delaysContentTouches {
+			for case let view as UIScrollView in cell.subviews {
+				view.delaysContentTouches = delaysContentTouches
+			}
+		}
 	}
 }
 
@@ -207,6 +221,7 @@ extension CellStyle: Equatable {
 		equality = equality && lhs.tintColor == rhs.tintColor
 		equality = equality && lhs.layoutMargins == rhs.layoutMargins
 		equality = equality && lhs.cornerRadius == rhs.cornerRadius
+		equality = equality && lhs.delaysContentTouches == rhs.delaysContentTouches
 		equality = equality && lhs.backgroundViewProvider?.isEqualTo(rhs.backgroundViewProvider) ?? (rhs.backgroundViewProvider == nil)
 		return equality
 	}


### PR DESCRIPTION
When a table view row has a button in it, the button won't have an immediate highlighted tapping state because the system needs to determine if the tapping was part of a scroll. The tapping state only appears when the button is long-pressed for 1 second or so. 

This PR adds a configurable `delaysContentTouches`, so that users of FTD have control over whether they want this behaviour or not. When this parameter is not used, it has the default system behaviour.

It appears that starting from iOS 7, each UITableViewCell has its own internal scroll view which interferes with the flag set on the table view, and it's been suggested by [the community](https://stackoverflow.com/a/22925576) to do this on the cell level as well for the desired behaviour. 