### PR TITLE
Improve diff performances with an early return for empty cases

### DIFF
--- a/FunctionalTableData.xcodeproj/project.pbxproj
+++ b/FunctionalTableData.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		4CA356761F322D7F0081BE90 /* TableSectionStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA356741F322D7F0081BE90 /* TableSectionStyleTests.swift */; };
 		4CCCE8481F8AA7F400C73258 /* TableItemLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CCCE8471F8AA7F400C73258 /* TableItemLayout.swift */; };
 		4CD535031F9E3A010041A3F9 /* CellStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CD535021F9E3A010041A3F9 /* CellStyleTests.swift */; };
+		5FFD843C230F207B007ADC5F /* FunctionaltableDataPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FFD843B230F207B007ADC5F /* FunctionaltableDataPerformanceTests.swift */; };
 		6C421788224D42C500D64AE2 /* ItemPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C421787224D42C500D64AE2 /* ItemPath.swift */; };
 		6C507AF62249268900D04521 /* FunctionalTableData+Cells.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C507AF52249268900D04521 /* FunctionalTableData+Cells.swift */; };
 		6C5F34C12231B91C00D57BEA /* ScrollViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C5F34C02231B91C00D57BEA /* ScrollViewDelegate.swift */; };
@@ -151,6 +152,7 @@
 		4CCCE8461F8AA7CD00C73258 /* UITableView+Reusable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+Reusable.swift"; sourceTree = "<group>"; };
 		4CCCE8471F8AA7F400C73258 /* TableItemLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableItemLayout.swift; sourceTree = "<group>"; };
 		4CD535021F9E3A010041A3F9 /* CellStyleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellStyleTests.swift; sourceTree = "<group>"; };
+		5FFD843B230F207B007ADC5F /* FunctionaltableDataPerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunctionaltableDataPerformanceTests.swift; sourceTree = "<group>"; };
 		6C421787224D42C500D64AE2 /* ItemPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemPath.swift; sourceTree = "<group>"; };
 		6C507AF52249268900D04521 /* FunctionalTableData+Cells.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "FunctionalTableData+Cells.swift"; sourceTree = "<group>"; };
 		6C5F34C02231B91C00D57BEA /* ScrollViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollViewDelegate.swift; sourceTree = "<group>"; };
@@ -303,6 +305,7 @@
 				36C9208C20D3EB7500DA4251 /* TableSectionsValidationTests.swift */,
 				9FF97DB2212CA23B006FA047 /* TableCellReuseTests.swift */,
 				6C910BA822529B390000D7E9 /* FunctionalTableDataDelegateTests.swift */,
+				5FFD843B230F207B007ADC5F /* FunctionaltableDataPerformanceTests.swift */,
 			);
 			path = FunctionalTableDataTests;
 			sourceTree = "<group>";
@@ -616,6 +619,7 @@
 				4CD535031F9E3A010041A3F9 /* CellStyleTests.swift in Sources */,
 				36C9208D20D3EB7500DA4251 /* TableSectionsValidationTests.swift in Sources */,
 				9FF97DB3212CA23B006FA047 /* TableCellReuseTests.swift in Sources */,
+				5FFD843C230F207B007ADC5F /* FunctionaltableDataPerformanceTests.swift in Sources */,
 				6C910BA922529B390000D7E9 /* FunctionalTableDataDelegateTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/FunctionalTableData/TableSectionChangeSet.swift
+++ b/FunctionalTableData/TableSectionChangeSet.swift
@@ -103,6 +103,17 @@ public final class TableSectionChangeSet {
 	* Whenever a section was also in the previous list, we compare the sections and perform the exact same algorithm on the individual rows.
 	*/
 	private func calculateChanges() {
+		//Early return for empty cases
+		if old.isEmpty == true && new.isEmpty == true {
+			return
+		} else if old.isEmpty == true && new.isEmpty == false {
+			insertedSections.insert(integersIn: 0...(new.count - 1))
+			return
+		} else if old.isEmpty == false && new.isEmpty == true {
+			deletedSections.insert(integersIn: 0...(old.count - 1))
+			return
+		}
+		
 		let newSections = Set(new.map { $0.key })
 		var oldSections: [String: Int] = Dictionary(minimumCapacity: old.count)
 		for (oldSectionIndex, oldSection) in old.enumerated() {

--- a/FunctionalTableDataTests/FunctionalDataTests.swift
+++ b/FunctionalTableDataTests/FunctionalDataTests.swift
@@ -90,27 +90,6 @@ class FunctionalDataTests: XCTestCase {
 		let cell = tableData.tableView?.visibleCells.first
 		XCTAssertEqual(cell?.accessibilityIdentifier, "sectionKey.cellKey")
 	}
-	
-	func testPerformance() {
-		let functionalData = FunctionalTableData()
-		
-		var oldSections: [TableSection] = []
-		for i in 0..<10 {
-			oldSections.append(
-				TableSection(
-					key: "section\(i)",
-					rows: (0..<10_000).map {
-						TestCaseCell(key: "size\($0)", state: TestCaseState(data: "data-\(i)"), cellUpdater: TestCaseState.updateView)
-					}
-				)
-			)
-		}
-		let newSections: [TableSection] = oldSections
-		
-		measure {
-			_ = functionalData.calculateTableChanges(oldSections: oldSections, newSections: newSections, visibleIndexPaths: [])
-		}
-	}
 }
 
 typealias TestCaseCell = HostCell<UIView, TestCaseState, LayoutMarginsTableItemLayout>

--- a/FunctionalTableDataTests/FunctionaltableDataPerformanceTests.swift
+++ b/FunctionalTableDataTests/FunctionaltableDataPerformanceTests.swift
@@ -1,0 +1,79 @@
+//
+//  FunctionaltableDataPerformanceTests.swift
+//  FunctionalTableDataTests
+//
+//  Created by Theo Ben Hassen on 2019-08-22.
+//  Copyright © 2019 Shopify. All rights reserved.
+//
+
+import XCTest
+@testable import FunctionalTableData
+
+class FunctionaltableDataPerformanceTests: XCTestCase {
+	private let functionalData = FunctionalTableData()
+	
+	func testPerformanceByMovingRows() {
+		let totalSections = 5
+		let totalRows = 200
+		
+		let oldSections =  mockSections(sectionsCount: totalSections, rowsCount: totalRows) { index -> String in
+			return "row-\(index)"
+		}
+
+		let newSections: [TableSection] = mockSections(sectionsCount: totalSections, rowsCount: totalRows) { index -> String in
+			return "row-\((totalRows - 1) - index)"
+		}
+
+		measure {
+			_ = functionalData.calculateTableChanges(oldSections: oldSections, newSections: newSections, visibleIndexPaths: [])
+		}
+	}
+	
+	func testPerformanceByAddingRows() {
+		let newSections: [TableSection] = mockSections(sectionsCount: 10, rowsCount: 10_000) { index -> String in
+			return "row-\(index)"
+		}
+		
+		measure {
+			_ = functionalData.calculateTableChanges(oldSections: [], newSections: newSections, visibleIndexPaths: [])
+		}
+	}
+	
+	func testPerformanceByDeletingRows() {
+		let oldSections: [TableSection] = mockSections(sectionsCount: 10, rowsCount: 10_000) { index -> String in
+			return "row-\(index)"
+		}
+		
+		measure {
+			_ = functionalData.calculateTableChanges(oldSections: oldSections, newSections: [], visibleIndexPaths: [])
+		}
+	}
+	
+	func testPerformanceByKeepingRows() {
+		let oldSections: [TableSection] = mockSections(sectionsCount: 10, rowsCount: 10_000) { index -> String in
+			return "row-\(index)"
+		}
+		
+		let newSections = oldSections
+		
+		measure {
+			_ = functionalData.calculateTableChanges(oldSections: oldSections, newSections: newSections, visibleIndexPaths: [])
+		}
+	}
+
+	private func mockSections(sectionsCount: Int, rowsCount: Int, keyBuilder: (Int) -> String) -> [TableSection] {
+		var sections: [TableSection] = []
+		for i in 0..<sectionsCount {
+			sections.append(
+				TableSection(
+					key: "section\(i)",
+					rows: (0..<rowsCount).map {
+						TestCaseCell(key: keyBuilder($0), state: TestCaseState(data: "data-\(i)"), cellUpdater: TestCaseState.updateView)
+					}
+				)
+			)
+		}
+		
+		return sections
+	}
+}


### PR DESCRIPTION
By avoiding to run the diff algorithm in full in case of old and/or new sections empty, we gained a few milliseconds in the ChangeSet `calculateChanges` function.

The performances tests have also been moved to a separate file.