### PR TITLE
Add proper equality for TableSection

### DIFF
--- a/FunctionalTableData.xcodeproj/project.pbxproj
+++ b/FunctionalTableData.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		02F106002326B9DF009865B0 /* TableSectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F105FF2326B9DF009865B0 /* TableSectionTests.swift */; };
 		17E57FE9208A404700BFCC3D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17E57FE8208A404700BFCC3D /* AppDelegate.swift */; };
 		17E57FEB208A404700BFCC3D /* TableExampleController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17E57FEA208A404700BFCC3D /* TableExampleController.swift */; };
 		17E57FF0208A404700BFCC3D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 17E57FEE208A404700BFCC3D /* Main.storyboard */; };
@@ -101,6 +102,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		02F105FF2326B9DF009865B0 /* TableSectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableSectionTests.swift; sourceTree = "<group>"; };
 		17E57FE6208A404700BFCC3D /* FunctionalTableDataDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FunctionalTableDataDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		17E57FE8208A404700BFCC3D /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		17E57FEA208A404700BFCC3D /* TableExampleController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableExampleController.swift; sourceTree = "<group>"; };
@@ -306,6 +308,7 @@
 				9FF97DB2212CA23B006FA047 /* TableCellReuseTests.swift */,
 				6C910BA822529B390000D7E9 /* FunctionalTableDataDelegateTests.swift */,
 				5FFD843B230F207B007ADC5F /* FunctionaltableDataPerformanceTests.swift */,
+				02F105FF2326B9DF009865B0 /* TableSectionTests.swift */,
 			);
 			path = FunctionalTableDataTests;
 			sourceTree = "<group>";
@@ -619,6 +622,7 @@
 				4CD535031F9E3A010041A3F9 /* CellStyleTests.swift in Sources */,
 				36C9208D20D3EB7500DA4251 /* TableSectionsValidationTests.swift in Sources */,
 				9FF97DB3212CA23B006FA047 /* TableCellReuseTests.swift in Sources */,
+				02F106002326B9DF009865B0 /* TableSectionTests.swift in Sources */,
 				5FFD843C230F207B007ADC5F /* FunctionaltableDataPerformanceTests.swift in Sources */,
 				6C910BA922529B390000D7E9 /* FunctionalTableDataDelegateTests.swift in Sources */,
 			);

--- a/FunctionalTableData/TableSection.swift
+++ b/FunctionalTableData/TableSection.swift
@@ -164,6 +164,20 @@ extension Array where Element: TableSectionType {
 
 extension TableSection: Equatable {
 	public static func ==(lhs: TableSection, rhs: TableSection) -> Bool {
-		return lhs.key == rhs.key
+		return lhs.key == rhs.key &&
+			(lhs.header == nil && rhs.header == nil || lhs.header?.isEqual(rhs.header) ?? false) &&
+			(lhs.footer == nil && rhs.footer == nil || lhs.footer?.isEqual(rhs.footer) ?? false) &&
+			isEqual(lhs: lhs.rows, rhs: rhs.rows) &&
+			lhs.style == rhs.style &&
+			(lhs.headerVisibilityAction == nil && rhs.headerVisibilityAction == nil || lhs.headerVisibilityAction != nil && rhs.headerVisibilityAction != nil) &&
+			(lhs.didMoveRow == nil && rhs.didMoveRow == nil || lhs.didMoveRow != nil && rhs.didMoveRow != nil)
+	}
+}
+
+private func isEqual(lhs: [CellConfigType], rhs: [CellConfigType]) -> Bool {
+	guard lhs.count == rhs.count else { return false }
+	
+	return zip(lhs, rhs).allSatisfy { (leftCell, rightCell) -> Bool in
+		return leftCell.isEqual(rightCell)
 	}
 }

--- a/FunctionalTableDataTests/TableSectionTests.swift
+++ b/FunctionalTableDataTests/TableSectionTests.swift
@@ -1,0 +1,149 @@
+//
+//  TableSectionTests.swift
+//  FunctionalTableDataTests
+//
+//  Created by Adam Becevello on 2019-09-09.
+//  Copyright © 2019 Shopify. All rights reserved.
+//
+
+import XCTest
+@testable import FunctionalTableData
+
+class TableSectionTests: XCTestCase {
+	private typealias LabelCell = HostCell<UILabel, String, LayoutMarginsTableItemLayout>
+	
+	func testEqualitySameObjectReturnsTrue() {
+		let first = tableSection()
+		let second = tableSection()
+		XCTAssertEqual(first, second)
+	}
+	
+	func testEqualityDifferentKeyReturnsFalse() {
+		let first = tableSection(key: "first")
+		let second = tableSection(key: "second")
+		XCTAssertNotEqual(first, second)
+	}
+	
+	func testEqualityNoHeadersReturnsTrue() {
+		var first = tableSection()
+		first.header = nil
+		var second = tableSection()
+		second.header = nil
+		XCTAssertEqual(first, second)
+	}
+	
+	func testEqualityDifferentHeaderReturnsFalse() {
+		let first = tableSection()
+		var second = tableSection()
+		second.header = TestHeaderFooter(state: TestHeaderFooterState(data: "second"))
+		XCTAssertNotEqual(first, second)
+	}
+	
+	func testEqualityNoFootersReturnsTrue() {
+		var first = tableSection()
+		first.footer = nil
+		var second = tableSection()
+		second.footer = nil
+		XCTAssertEqual(first, second)
+	}
+	
+	func testEqualityDifferentFooterReturnsFalse() {
+		let first = tableSection()
+		var second = tableSection()
+		second.footer = TestHeaderFooter(state: TestHeaderFooterState(data: "second"))
+		XCTAssertNotEqual(first, second)
+	}
+	
+	func testEqualityDifferentRowsReturnsFalse() {
+		let first = tableSection()
+		var second = tableSection()
+		second.rows = []
+		XCTAssertNotEqual(first, second)
+	}
+	
+	func testEqualityDifferentStyleReturnsFalse() {
+		let first = tableSection()
+		var second = tableSection()
+		second.style = SectionStyle(separators: SectionStyle.Separators(top: Separator.Style.full, bottom: nil, interitem: nil))
+		XCTAssertNotEqual(first, second)
+	}
+	
+	func testEqualityNoHeaderVisibilityActionReturnsTrue() {
+		var first = tableSection()
+		first.headerVisibilityAction = nil
+		var second = tableSection()
+		second.headerVisibilityAction = nil
+		XCTAssertEqual(first, second)
+	}
+	
+	func testEqualityDifferentHeaderVisibilityActionReturnsFalse() {
+		let first = tableSection()
+		var second = tableSection()
+		second.headerVisibilityAction = nil
+		XCTAssertNotEqual(first, second)
+	}
+	
+	func testEqualityNoDidMoveRowReturnsTrue() {
+		var first = tableSection()
+		first.didMoveRow = nil
+		var second = tableSection()
+		second.didMoveRow = nil
+		XCTAssertEqual(first, second)
+	}
+	
+	func testEqualityDifferentDidMoveRowReturnsFalse() {
+		let first = tableSection()
+		var second = tableSection()
+		second.didMoveRow = nil
+		XCTAssertNotEqual(first, second)
+	}
+	
+	private func tableSection(key: String = "key") -> TableSection {
+		let cell = mockCell(key: "cell", style: nil)
+		let header = TestHeaderFooter(state: TestHeaderFooterState(data: "header"))
+		let footer = TestHeaderFooter(state: TestHeaderFooterState(data: "footer"))
+		let style = SectionStyle(separators: SectionStyle.Separators())
+		var tableSection = TableSection(key: key, rows: [cell], header: header, footer: footer, style: style)
+		tableSection.didMoveRow = { _, _ in }
+		tableSection.headerVisibilityAction = { _, _ in }
+		return tableSection
+	}
+	
+	private func mockCell(key: String, style: CellStyle?) -> CellConfigType {
+		return LabelCell(
+			key: key,
+			style: style,
+			state: "",
+			cellUpdater: { _, _ in })
+	}
+}
+
+fileprivate struct TestHeaderFooterState: TableHeaderFooterStateType, Equatable {
+	let insets: UIEdgeInsets = .zero
+	let height: CGFloat = 0
+	let topSeparatorHidden: Bool = true
+	let bottomSeparatorHidden: Bool = true
+	var data: String
+}
+
+fileprivate struct TestHeaderFooter: TableHeaderFooterConfigType {
+	typealias HeaderFooter = TableHeaderFooter<UIView, LayoutMarginsTableItemLayout>
+	let state: TestHeaderFooterState?
+
+	func register(with tableView: UITableView) {
+		tableView.registerReusableHeaderFooterView(HeaderFooter.self)
+	}
+
+	func dequeueHeaderFooter(from tableView: UITableView) -> UITableViewHeaderFooterView? {
+		return tableView.dequeueReusableHeaderFooterView(HeaderFooter.self)
+	}
+
+	func isEqual(_ other: TableHeaderFooterConfigType?) -> Bool {
+		guard let other = other as? TestHeaderFooter else { return false }
+		return state == other.state
+	}
+
+	var height: CGFloat {
+		return state?.height ?? 0
+	}
+}


### PR DESCRIPTION
Currently TableSection equality conformance only checks if the keys are equal. Although this specific equality function isn't used during FTD diffing, the fact this equality function is incomplete is causing sections to fail to update in some limited cases.

This PR implements proper equality of TableSections by checking all properties, including all rows.