### PR TITLE
Add UICollectionViewCell accessibility identifier

### DIFF
--- a/Sources/FunctionalTableData/CollectionView/FunctionalCollectionData+UICollectionViewDataSource.swift
+++ b/Sources/FunctionalTableData/CollectionView/FunctionalCollectionData+UICollectionViewDataSource.swift
@@ -29,7 +29,8 @@ extension FunctionalCollectionData {
 			let row = indexPath.item
 			let cellConfig = sectionData[row]
 			let cell = cellConfig.dequeueCell(from: collectionView, at: indexPath)
-			
+			cell.accessibilityIdentifier = ItemPath(sectionKey: sectionData.key, itemKey: cellConfig.key).description
+
 			cellConfig.update(cell: cell, in: collectionView)
 			let style = cellConfig.style ?? CellStyle()
 			style.configure(cell: cell, in: collectionView)


### PR DESCRIPTION
Matching the implementation for `UITableViewCell`: https://github.com/Shopify/FunctionalTableData/blob/deef00cac84dece1d494091649dafeb12c9952cf/Sources/FunctionalTableData/TableView/FunctionalTableData%2BUITableViewDataSource.swift#L34.

This makes it possible for UI tests to find `UICollectionViewCell` objects in the view hierarchy.