### PR TITLE
Mutable cell actions

### DIFF
--- a/Sources/FunctionalTableData/CellActions.swift
+++ b/Sources/FunctionalTableData/CellActions.swift
@@ -137,32 +137,32 @@ public struct CellActions {
 	
 	/// The action to perform when the cell will be selected.
 	/// - Important: When the `canSelectAction` is called, it is passed a `CanSelectCallback` closure. It is the responsibility of the action to eventually call the passed in closure providing either a `true` or `false` value to it. This passed in value determines if the selection will be performed or not.
-	public let canSelectAction: CanSelectAction?
+	public var canSelectAction: CanSelectAction?
 	/// The action to perform when the cell is selected
-	public let selectionAction: SelectionAction?
+	public var selectionAction: SelectionAction?
 	/// The action to perform when the cell is deselected
-	public let deselectionAction: SelectionAction?
+	public var deselectionAction: SelectionAction?
 	
 	/// The swipe actions to display on the leading edge of the row.
 	///
 	/// Use this method to return a set of actions to display when the user swipes the row. The actions you return are displayed on the leading edge of the row. For example, in a left-to-right language environment, they are displayed on the left side of the row when the user swipes from left to right.
-	public let leadingActionConfiguration: SwipeActionsConfiguration?
+	public var leadingActionConfiguration: SwipeActionsConfiguration?
 	
 	/// The swipe actions to display next to the trailing edge of the row. Return nil if you want the table to display the default set of actions.
 	///
 	/// Use this method to return a set of actions to display when the user swipes the row. The actions you return are displayed on the trailing edge of the row. For example, in a left-to-right language environment, they are displayed on the right side of the row when the user swipes from right to left.
-	public let trailingActionConfiguration: SwipeActionsConfiguration?
+	public var trailingActionConfiguration: SwipeActionsConfiguration?
 	
 	/// Indicates if the cell can perform a given action.
-	public let canPerformAction: CanPerformAction?
+	public var canPerformAction: CanPerformAction?
 	/// Indicates if the cell can be manually moved by the user.
-	public let canBeMoved: Bool
+	public var canBeMoved: Bool
 	/// The action to perform when the cell becomes visible.
-	public let visibilityAction: VisibilityAction?
+	public var visibilityAction: VisibilityAction?
 	/// The action to perform when the cell is 3D touched by the user.
 	/// - note: By default the `UIViewControllerPreviewing` will have its `sourceRect` configured to be the entire cells frame.
 	/// The given `previewingViewControllerAction` however can override this as it sees fit.
-	public let previewingViewControllerAction: PreviewingViewControllerAction?
+	public var previewingViewControllerAction: PreviewingViewControllerAction?
 	
 	public init(
 		canSelectAction: CanSelectAction? = nil,

--- a/Sources/FunctionalTableData/CellConfigType.swift
+++ b/Sources/FunctionalTableData/CellConfigType.swift
@@ -21,7 +21,7 @@ public protocol CellConfigType: TableItemConfigType, CollectionItemConfigType {
 	/// Indicates a cell style. See `CellStyle` for more information.
 	var style: CellStyle? { get set }
 	/// Indicates all the possible actions a cell can perform. See `CellActions` for more information.
-	var actions: CellActions { get }
+	var actions: CellActions { get set }
 	
 	/// Update the view state of a `UITableViewCell`. It is up to implementors of the protocol to determine what this means.
 	///

--- a/Sources/FunctionalTableData/HostCell.swift
+++ b/Sources/FunctionalTableData/HostCell.swift
@@ -16,7 +16,7 @@ public struct HostCell<View, State, Layout>: CellConfigType where View: UIView, 
 	
 	public let key: String
 	public var style: CellStyle?
-	public let actions: CellActions
+	public var actions: CellActions
 	/// Contains the state information of a cell.
 	public let state: State
 	/// A function that updates a cell's view to match the current state. It receives two values, the view instance and an optional state instance. The purpose of this function is to update the view to reflect that of the given state. The reason that the state is optional is because cells may move into the reuse queue. When this happens they no longer have a state and the updater function is called giving the opportunity to reset the view to its default value.


### PR DESCRIPTION
## What

This change allows the cell actions to be changed in place. They are still structs, so everything will still be copied around nicely.

## Use case

I am working on a view controller that "auto magically" adds `visibilityAction` to all the cells it passes through its render, in order to do this I need to be able to modify the actions directly and set them back. Pretty much this

```swift
content.rows.enumerated().map { index, row in
	var row = row
	/// Store any previous visibility action to be called side by side with our new one.
	let oldVisibilityAction = row.actions.visibilityAction
	row.actions.visibilityAction = { [weak self] view, visible in
		oldVisibilityAction?(view, visible)
		guard visible else { return }
			self?.didChangePage(to: index)
		}
		return row
}
```