### PR TITLE
Moved was using the wrong equatable

### DIFF
--- a/Sources/FunctionalTableData/TableSectionChangeSet.swift
+++ b/Sources/FunctionalTableData/TableSectionChangeSet.swift
@@ -11,10 +11,6 @@ import Foundation
 struct Moved<T: Equatable>: Equatable {
 	let from: T
 	let to: T
-
-	static func ==(lhs: Moved<T>, rhs: Moved<T>) -> Bool {
-		return lhs.from == lhs.from && lhs.to == rhs.to
-	}
 }
 
 // Compares two arrays of TableSections and produces the operations


### PR DESCRIPTION
Small fix that has been lurking around for a while. Thanks to Toussaint Stewart for catching this!