### PR TITLE
adding basic accessibility struct

### DIFF
--- a/FunctionalTableData.xcodeproj/project.pbxproj
+++ b/FunctionalTableData.xcodeproj/project.pbxproj
@@ -50,6 +50,8 @@
 		6C27C0BE2372014100EA73F9 /* TableSectionStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C27C0A92372008900EA73F9 /* TableSectionStyleTests.swift */; };
 		6C27C0BF2372014100EA73F9 /* TableSectionsValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C27C0AA2372008900EA73F9 /* TableSectionsValidationTests.swift */; };
 		6C27C0C02372014100EA73F9 /* TableSectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C27C0AB2372008900EA73F9 /* TableSectionTests.swift */; };
+		6CB4D378246B904B00BFD647 /* AccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CB4D377246B904B00BFD647 /* AccessibilityTests.swift */; };
+		6CEFBC462458902400E6AF19 /* Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CEFBC452458902400E6AF19 /* Accessibility.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -109,6 +111,8 @@
 		6C27C0AA2372008900EA73F9 /* TableSectionsValidationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableSectionsValidationTests.swift; sourceTree = "<group>"; };
 		6C27C0AB2372008900EA73F9 /* TableSectionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableSectionTests.swift; sourceTree = "<group>"; };
 		6C27C0B6237200DC00EA73F9 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		6CB4D377246B904B00BFD647 /* AccessibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityTests.swift; sourceTree = "<group>"; };
+		6CEFBC452458902400E6AF19 /* Accessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Accessibility.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -153,13 +157,16 @@
 		6C27C04A2371FFB000EA73F9 /* FunctionalTableData */ = {
 			isa = PBXGroup;
 			children = (
+				6CEFBC452458902400E6AF19 /* Accessibility.swift */,
 				6C27C06E2372007A00EA73F9 /* BackgroundViewProvider.swift */,
 				6C27C0702372007A00EA73F9 /* CellActions.swift */,
 				6C27C0712372007A00EA73F9 /* CellConfigType.swift */,
 				6C27C0832372007B00EA73F9 /* CellStyle.swift */,
 				6C27C0632372007A00EA73F9 /* CollectionView */,
 				6C27C06A2372007A00EA73F9 /* Extensions */,
+				6C27C04B2371FFB000EA73F9 /* FunctionalTableData.h */,
 				6C27C06F2372007A00EA73F9 /* HostCell.swift */,
+				6C27C04C2371FFB000EA73F9 /* Info.plist */,
 				6C27C0762372007B00EA73F9 /* ItemPath.swift */,
 				6C27C0622372007A00EA73F9 /* ObjCExceptionRethrower.swift */,
 				6C27C0802372007B00EA73F9 /* Reusable.swift */,
@@ -171,8 +178,6 @@
 				6C27C0742372007B00EA73F9 /* TableSectionChangeSet.swift */,
 				6C27C0812372007B00EA73F9 /* TableSectionHeaderFooter.swift */,
 				6C27C0772372007B00EA73F9 /* TableView */,
-				6C27C04B2371FFB000EA73F9 /* FunctionalTableData.h */,
-				6C27C04C2371FFB000EA73F9 /* Info.plist */,
 			);
 			name = FunctionalTableData;
 			path = Sources/FunctionalTableData;
@@ -181,6 +186,7 @@
 		6C27C0552371FFB000EA73F9 /* FunctionalTableDataTests */ = {
 			isa = PBXGroup;
 			children = (
+				6CB4D377246B904B00BFD647 /* AccessibilityTests.swift */,
 				6C27C0A72372008900EA73F9 /* CellStyleTests.swift */,
 				6C27C0A42372008900EA73F9 /* FunctionalDataTests.swift */,
 				6C27C0A82372008900EA73F9 /* FunctionalTableDataDelegateTests.swift */,
@@ -373,6 +379,7 @@
 				6C27C0892372007B00EA73F9 /* CollectionItemConfigType.swift in Sources */,
 				6C27C08B2372007B00EA73F9 /* UIView+Extensions.swift in Sources */,
 				6C27C08E2372007B00EA73F9 /* BackgroundViewProvider.swift in Sources */,
+				6CEFBC462458902400E6AF19 /* Accessibility.swift in Sources */,
 				6C27C09F2372007B00EA73F9 /* Reusable.swift in Sources */,
 				6C27C09C2372007B00EA73F9 /* TableItemConfigType.swift in Sources */,
 				6C27C09E2372007B00EA73F9 /* TableData.swift in Sources */,
@@ -397,6 +404,7 @@
 				6C27C0BB2372014100EA73F9 /* FunctionaltableDataPerformanceTests.swift in Sources */,
 				6C27C0C02372014100EA73F9 /* TableSectionTests.swift in Sources */,
 				6C27C0B82372014100EA73F9 /* CellStyleTests.swift in Sources */,
+				6CB4D378246B904B00BFD647 /* AccessibilityTests.swift in Sources */,
 				6C27C0BF2372014100EA73F9 /* TableSectionsValidationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/FunctionalTableData/Accessibility.swift
+++ b/Sources/FunctionalTableData/Accessibility.swift
@@ -1,0 +1,42 @@
+//
+//  Accessibility.swift
+//  FunctionalTableData
+//
+//  Created by Geoffrey Foster on 2020-04-28.
+//  Copyright © 2020 Shopify. All rights reserved.
+//
+
+import UIKit
+
+public struct Accessibility: Equatable {
+	public var identifier: String?
+	public var userInputLabels: [String]?
+	
+	public init(identifier: String? = nil, userInputLabels: [String]? = nil) {
+		self.identifier = identifier
+		self.userInputLabels = userInputLabels
+	}
+	
+	internal func with(defaultIdentifier: String) -> Accessibility {
+		guard identifier == nil else { return self }
+		var copy = self
+		copy.identifier = defaultIdentifier
+		return copy
+	}
+}
+
+extension Accessibility {
+	func apply(to cell: UITableViewCell) {
+		cell.accessibilityIdentifier = identifier
+		if #available(iOS 13.0, *) {
+			cell.accessibilityUserInputLabels = userInputLabels
+		}
+	}
+	
+	func apply(to cell: UICollectionViewCell) {
+		cell.accessibilityIdentifier = identifier
+		if #available(iOS 13.0, *) {
+			cell.accessibilityUserInputLabels = userInputLabels
+		}
+	}
+}

--- a/Sources/FunctionalTableData/CellConfigType.swift
+++ b/Sources/FunctionalTableData/CellConfigType.swift
@@ -23,6 +23,8 @@ public protocol CellConfigType: TableItemConfigType, CollectionItemConfigType {
 	/// Indicates all the possible actions a cell can perform. See `CellActions` for more information.
 	var actions: CellActions { get set }
 	
+	var accessibility: Accessibility { get set }
+	
 	/// Update the view state of a `UITableViewCell`. It is up to implementors of the protocol to determine what this means.
 	///
 	/// - Parameters:

--- a/Sources/FunctionalTableData/CollectionView/FunctionalCollectionData+UICollectionViewDataSource.swift
+++ b/Sources/FunctionalTableData/CollectionView/FunctionalCollectionData+UICollectionViewDataSource.swift
@@ -29,8 +29,8 @@ extension FunctionalCollectionData {
 			let row = indexPath.item
 			let cellConfig = sectionData[row]
 			let cell = cellConfig.dequeueCell(from: collectionView, at: indexPath)
-			cell.accessibilityIdentifier = ItemPath(sectionKey: sectionData.key, itemKey: cellConfig.key).description
-
+			let accessibilityIdentifier = ItemPath(sectionKey: sectionData.key, itemKey: cellConfig.key).description
+			cellConfig.accessibility.with(defaultIdentifier: accessibilityIdentifier).apply(to: cell)
 			cellConfig.update(cell: cell, in: collectionView)
 			let style = cellConfig.style ?? CellStyle()
 			style.configure(cell: cell, in: collectionView)

--- a/Sources/FunctionalTableData/HostCell.swift
+++ b/Sources/FunctionalTableData/HostCell.swift
@@ -17,15 +17,17 @@ public struct HostCell<View, State, Layout>: CellConfigType where View: UIView, 
 	public let key: String
 	public var style: CellStyle?
 	public var actions: CellActions
+	public var accessibility: Accessibility
 	/// Contains the state information of a cell.
 	public let state: State
 	/// A function that updates a cell's view to match the current state. It receives two values, the view instance and an optional state instance. The purpose of this function is to update the view to reflect that of the given state. The reason that the state is optional is because cells may move into the reuse queue. When this happens they no longer have a state and the updater function is called giving the opportunity to reset the view to its default value.
 	public let cellUpdater: (_ view: View, _ state: State?) -> Void
 	
-	public init(key: String, style: CellStyle? = nil, actions: CellActions = CellActions(), state: State, cellUpdater: @escaping (_ view: View, _ state: State?) -> Void) {
+	public init(key: String, style: CellStyle? = nil, actions: CellActions = CellActions(), accessibility: Accessibility = Accessibility(), state: State, cellUpdater: @escaping (_ view: View, _ state: State?) -> Void) {
 		self.key = key
 		self.style = style
 		self.actions = actions
+		self.accessibility = accessibility
 		self.state = state
 		self.cellUpdater = cellUpdater
 	}
@@ -95,7 +97,7 @@ public struct HostCell<View, State, Layout>: CellConfigType where View: UIView, 
 	
 	public func isEqual(_ other: CellConfigType) -> Bool {
 		if let other = other as? HostCell<View, State, Layout> {
-			return state == other.state
+			return state == other.state && accessibility == other.accessibility
 		}
 		return false
 	}
@@ -107,7 +109,7 @@ public struct HostCell<View, State, Layout>: CellConfigType where View: UIView, 
 }
 
 extension HostCell {
-	public init<T: RawRepresentable>(key: T, style: CellStyle? = nil, actions: CellActions = CellActions(), state: State, cellUpdater: @escaping (_ view: View, _ state: State?) -> Void) where T.RawValue == String {
-		self.init(key: key.rawValue, style: style, actions: actions, state: state, cellUpdater: cellUpdater)
+	public init<T: RawRepresentable>(key: T, style: CellStyle? = nil, actions: CellActions = CellActions(), accessibility: Accessibility = Accessibility(), state: State, cellUpdater: @escaping (_ view: View, _ state: State?) -> Void) where T.RawValue == String {
+		self.init(key: key.rawValue, style: style, actions: actions, accessibility: accessibility, state: state, cellUpdater: cellUpdater)
 	}
 }

--- a/Sources/FunctionalTableData/TableView/FunctionalTableData+UITableViewDataSource.swift
+++ b/Sources/FunctionalTableData/TableView/FunctionalTableData+UITableViewDataSource.swift
@@ -31,8 +31,8 @@ extension FunctionalTableData {
 			let row = indexPath.row
 			let cellConfig = sectionData[row]
 			let cell = cellConfig.dequeueCell(from: tableView, at: indexPath)
-			cell.accessibilityIdentifier = ItemPath(sectionKey: sectionData.key, itemKey: cellConfig.key).description
-			
+			let accessibilityIdentifier = ItemPath(sectionKey: sectionData.key, itemKey: cellConfig.key).description
+			cellConfig.accessibility.with(defaultIdentifier: accessibilityIdentifier).apply(to: cell)
 			cellStyler.update(cell: cell, cellConfig: cellConfig, at: indexPath, in: tableView)
 			
 			return cell

--- a/Tests/FunctionalTableDataTests/AccessibilityTests.swift
+++ b/Tests/FunctionalTableDataTests/AccessibilityTests.swift
@@ -1,0 +1,19 @@
+//
+//  AccessibilityTests.swift
+//  FunctionalTableDataTests
+//
+//  Created by Geoffrey Foster on 2020-05-12.
+//  Copyright © 2020 Shopify. All rights reserved.
+//
+
+import XCTest
+@testable import FunctionalTableData
+
+class AccessibilityTests: XCTestCase {
+	
+	func testAccessibilityIdentifier() {
+		XCTAssertEqual(Accessibility().with(defaultIdentifier: "success").identifier, "success")
+		XCTAssertEqual(Accessibility(identifier: "success").with(defaultIdentifier: "fail").identifier, "success")
+	}
+	
+}

--- a/Tests/FunctionalTableDataTests/TableSectionChangeSetTests.swift
+++ b/Tests/FunctionalTableDataTests/TableSectionChangeSetTests.swift
@@ -573,6 +573,24 @@ class TableSectionChangeSetTests: XCTestCase {
 		XCTAssertEqual(changes.count, 1)
 		XCTAssertEqual(changes.reloadedRows, [IndexPath(row: 0, section: 0)])
 	}
+	
+	func testAccessibilityChange() {
+		let oldSection = TableSection(key: "section1", rows: [
+			TestCaseCell(key: "row1", accessibility: Accessibility(identifier: "initial", userInputLabels: ["row1"]), state: TestCaseState(data: "red"), cellUpdater: TestCaseState.updateView)
+		])
+		
+		let newSection = TableSection(key: "section1", rows: [
+			TestCaseCell(key: "row1", accessibility: Accessibility(identifier: "new", userInputLabels: ["row1"]), state: TestCaseState(data: "red"), cellUpdater: TestCaseState.updateView)
+		])
+		
+		let changes = TableSectionChangeSet(
+			old: [oldSection],
+			new: [newSection],
+			visibleIndexPaths: [IndexPath(row: 0, section: 0)]
+		)
+		XCTAssertEqual(changes.count, 1)
+		XCTAssertEqual(changes.updates.map { $0.index }, [IndexPath(row: 0, section: 0)])
+	}
 }
 
 fileprivate typealias LabelCell = HostCell<UILabel, String, LayoutMarginsTableItemLayout>


### PR DESCRIPTION
Starting point for a bit of extra accessibility data. The struct stores the iOS 13+ `userInputLabels` that are what the voice control system uses. This lets us put proper labels on cells so they can be tapped, instead of relying on the full accessibility string which can be quite cumbersome to speak.