### PR TITLE
Make reloadEntireTableThreshold configurable

### DIFF
--- a/Sources/FunctionalTableData/CollectionView/FunctionalCollectionData.swift
+++ b/Sources/FunctionalTableData/CollectionView/FunctionalCollectionData.swift
@@ -14,6 +14,9 @@ import UIKit
 public class FunctionalCollectionData {
 	/// Specifies the desired exception handling behaviour.
 	public static var exceptionHandler: FunctionalTableDataExceptionHandler?
+
+	/// Specifies the minimum amount of table changes that will trigger a reload of the entire table.
+	public static var reloadEntireTableThreshold = 20
 	
 	public typealias KeyPath = ItemPath
 	
@@ -27,7 +30,6 @@ public class FunctionalCollectionData {
 	private var sections: [TableSection] {
 		return data.sections
 	}
-	private static let reloadEntireTableThreshold = 20
 	
 	private let renderAndDiffQueue: OperationQueue
 	private let name: String

--- a/Sources/FunctionalTableData/TableView/FunctionalTableData.swift
+++ b/Sources/FunctionalTableData/TableView/FunctionalTableData.swift
@@ -35,6 +35,9 @@ public class FunctionalTableData {
 	
 	/// Specifies the desired exception handling behaviour.
 	public static var exceptionHandler: FunctionalTableDataExceptionHandler?
+
+	/// Specifies the minimum amount of table changes that will trigger a reload of the entire table.
+	public static var reloadEntireTableThreshold = 20
 	
 	public typealias KeyPath = ItemPath
 	
@@ -45,7 +48,6 @@ public class FunctionalTableData {
 	}
 	
 	private let data: TableData
-	private static let reloadEntireTableThreshold = 20
 	
 	private let renderAndDiffQueue: OperationQueue
 	private let name: String


### PR DESCRIPTION
If you have a table diff that changes more than 20 rows FTD will reload the entire table rather than applying all the changes separately. Unfortunately you lose animations when this happens. This makes the `reloadEntireTableThreshold` configurable at a global level to allow consumers to animate more than 20 changes at once. 