### PR TITLE
Adds support for a selectionBackgroundProvider in the cellStyle.

### DIFF
--- a/Sources/FunctionalTableData/CellStyle.swift
+++ b/Sources/FunctionalTableData/CellStyle.swift
@@ -52,6 +52,8 @@ public struct CellStyle {
 	public var accessoryType: UITableViewCell.AccessoryType
 	/// The view's selection color.
 	public var selectionColor: UIColor?
+	/// Provide the view that is displayed behind the selected cell's other content.
+	public var selectionBackgroundViewProvider: BackgroundViewProvider?
 	/// The view's background color.
 	public var backgroundColor: UIColor?
 	/// The view that is displayed behind the cell's other content.
@@ -120,6 +122,7 @@ public struct CellStyle {
 				highlight: Bool? = nil,
 				accessoryType: UITableViewCell.AccessoryType = .none,
 				selectionColor: UIColor? = CellStyle.defaultSelectionColor,
+				selectionBackgroundViewProvider: BackgroundViewProvider? = nil,
 				backgroundColor: UIColor? = CellStyle.defaultBackgroundColor,
 				backgroundViewProvider: BackgroundViewProvider? = nil,
 				tintColor: UIColor? = nil,
@@ -133,6 +136,7 @@ public struct CellStyle {
 		self.highlight = highlight
 		self.accessoryType = accessoryType
 		self.selectionColor = selectionColor
+		self.selectionBackgroundViewProvider = selectionBackgroundViewProvider
 		self.backgroundColor = backgroundColor
 		self.backgroundViewProvider = backgroundViewProvider
 		self.tintColor = tintColor
@@ -163,6 +167,10 @@ public struct CellStyle {
 			cell.selectedBackgroundView = selectedBackgroundView
 		} else {
 			cell.selectedBackgroundView = nil
+		}
+		
+		if let selectedBackgroundView = selectionBackgroundViewProvider?.backgroundView() {
+			cell.selectedBackgroundView = selectedBackgroundView
 		}
 		
 		cell.layer.cornerRadius = cornerRadius
@@ -203,6 +211,10 @@ public struct CellStyle {
 			cell.selectedBackgroundView = selectedBackgroundView
 		} else {
 			cell.selectedBackgroundView = nil
+		}
+		
+		if let selectedBackgroundView = selectionBackgroundViewProvider?.backgroundView() {
+			cell.selectedBackgroundView = selectedBackgroundView
 		}
 		
 		cell.accessoryType = accessoryType

--- a/Sources/FunctionalTableData/CellStyle.swift
+++ b/Sources/FunctionalTableData/CellStyle.swift
@@ -161,12 +161,11 @@ public struct CellStyle {
 			cell.contentView.insetsLayoutMarginsFromSafeArea = false
 		}
 		
+		cell.selectedBackgroundView = nil
 		if let selectionColor = selectionColor {
 			let selectedBackgroundView = UIView()
 			selectedBackgroundView.backgroundColor = selectionColor
 			cell.selectedBackgroundView = selectedBackgroundView
-		} else {
-			cell.selectedBackgroundView = nil
 		}
 		
 		if let selectedBackgroundView = selectionBackgroundViewProvider?.backgroundView() {
@@ -205,12 +204,12 @@ public struct CellStyle {
 		cell.tintColor = tintColor
 		
 		cell.selectionStyle = (highlight ?? false) ? .default : .none
+		
+		cell.selectedBackgroundView = nil
 		if let selectionColor = selectionColor {
 			let selectedBackgroundView = UIView()
 			selectedBackgroundView.backgroundColor = selectionColor
 			cell.selectedBackgroundView = selectedBackgroundView
-		} else {
-			cell.selectedBackgroundView = nil
 		}
 		
 		if let selectedBackgroundView = selectionBackgroundViewProvider?.backgroundView() {

--- a/Tests/FunctionalTableDataTests/CellStyleTests.swift
+++ b/Tests/FunctionalTableDataTests/CellStyleTests.swift
@@ -151,6 +151,16 @@ class StyleTests: XCTestCase {
 	}
 	
 	func testSelectionBackgroundProvider() {
+		let selectedBackgroundViewProvider = ColoredBackgroundProvider(color: .orange)
+		cell.style?.selectionBackgroundViewProvider = selectedBackgroundViewProvider
+		applyStyle()
+		XCTAssertEqual(.orange, viewCell.selectedBackgroundView?.backgroundColor)
+		cell.style?.selectionBackgroundViewProvider = nil
+		applyStyle()
+		XCTAssertNil(viewCell.selectedBackgroundView?.backgroundColor)
+	}
+
+	func testSelectionColorWithSelectionBackgroundProvider() {
 		cell.style?.selectionColor = .red
 		applyStyle()
 		XCTAssertEqual(.red, viewCell.selectedBackgroundView?.backgroundColor)
@@ -158,6 +168,16 @@ class StyleTests: XCTestCase {
 		cell.style?.selectionBackgroundViewProvider = selectedBackgroundViewProvider
 		applyStyle()
 		XCTAssertEqual(.orange, viewCell.selectedBackgroundView?.backgroundColor)
+	}
+
+	func testSelectionBackgroundProviderWithBackgroundViewProvider() {
+		let backgroundViewProvider = ColoredBackgroundProvider(color: .blue)
+		cell.style?.backgroundViewProvider = backgroundViewProvider
+		let selectedBackgroundViewProvider = ColoredBackgroundProvider(color: .orange)
+		cell.style?.selectionBackgroundViewProvider = selectedBackgroundViewProvider
+		applyStyle()
+		XCTAssertEqual(.orange, viewCell.selectedBackgroundView?.backgroundColor)
+		XCTAssertEqual(.blue, viewCell.backgroundView?.backgroundColor)
 	}
 	
 	func testBackground() {

--- a/Tests/FunctionalTableDataTests/CellStyleTests.swift
+++ b/Tests/FunctionalTableDataTests/CellStyleTests.swift
@@ -150,6 +150,16 @@ class StyleTests: XCTestCase {
 		XCTAssertNil(viewCell.selectedBackgroundView?.backgroundColor)
 	}
 	
+	func testSelectionBackgroundProvider() {
+		cell.style?.selectionColor = .red
+		applyStyle()
+		XCTAssertEqual(.red, viewCell.selectedBackgroundView?.backgroundColor)
+		let selectedBackgroundViewProvider = ColoredBackgroundProvider(color: .orange)
+		cell.style?.selectionBackgroundViewProvider = selectedBackgroundViewProvider
+		applyStyle()
+		XCTAssertEqual(.orange, viewCell.selectedBackgroundView?.backgroundColor)
+	}
+	
 	func testBackground() {
 		applyStyle()
 		XCTAssertEqual(viewCell.backgroundColor, CellStyle.defaultBackgroundColor)


### PR DESCRIPTION
The `CellStyle` already takes in a `BackgroundViewProvider` for the `backgroundView` property, but we can easily extend this idea to also take in a `BackgroundViewProvider` for the `selectedBackgroundView` property as well. 

This will allow for custom views on selection of cells. 