### PR TITLE
Support multi item selection via gestures

### DIFF
--- a/Sources/FunctionalTableData/CellActions.swift
+++ b/Sources/FunctionalTableData/CellActions.swift
@@ -227,7 +227,8 @@ public struct CellActions {
 	public typealias DeselectionAction = (_ sender: UIView) -> SelectionState
 	public typealias CanPerformAction = (_ selector: Selector) -> Bool
 	public typealias VisibilityAction = (_ cell: UIView, _ visible: Bool) -> Void
-	public typealias BeginMultiSelectAction = () -> Void
+	public typealias ShouldBeginMultiSelectAction = () -> Bool
+	public typealias DidBeginMultiSelectAction = () -> Void
 	/// Closure type that is executed when the user 3D-touches on a cell
 	/// - parameter cell: the cell in which the 3D-touch occured
 	/// - parameter point: The point where the 3D-touch occured, translated to the coordinate space of the cell
@@ -269,10 +270,14 @@ public struct CellActions {
 	/// UIContextMenus were introduced in iOS 13. This property is not used on earlier versions of iOS.
 	public var contextMenuConfiguration: ContextMenuConfiguration?
 	
+	/// Whether the multi select drag gesture can begin from this cell.
+	/// Also require's the tableview's `allowsMultipleSelectionDuringEditing` property be set to `true`.
+	public var shouldBeginMultiSelectAction: ShouldBeginMultiSelectAction?
+	
 	/// Action performed when multi list selection has begun on this cell.
 	/// This automatically enables the tableView's editing mode _before_ this closure is called.
 	/// Require's the tableview's `allowsMultipleSelectionDuringEditing` property be set to `true`.
-	public var beginMultiSelectAction: BeginMultiSelectAction?
+	public var didBeginMultiSelectAction: DidBeginMultiSelectAction?
 	
 	public init(
 		canSelectAction: CanSelectAction? = nil,
@@ -285,7 +290,8 @@ public struct CellActions {
 		visibilityAction: VisibilityAction? = nil,
 		previewingViewControllerAction: PreviewingViewControllerAction? = nil,
 		contextMenuConfiguration: ContextMenuConfiguration? = nil,
-		beginMultiSelectAction: BeginMultiSelectAction? = nil) {
+		shouldBeginMultiSelectAction: ShouldBeginMultiSelectAction? = nil,
+		didBeginMultiSelectAction: DidBeginMultiSelectAction? = nil) {
 		self.canSelectAction = canSelectAction
 		self.selectionAction = selectionAction
 		self.deselectionAction = deselectionAction
@@ -303,7 +309,8 @@ public struct CellActions {
 			self.previewingViewControllerAction = nil
 		}
 		self.contextMenuConfiguration = contextMenuConfiguration
-		self.beginMultiSelectAction = beginMultiSelectAction
+		self.shouldBeginMultiSelectAction = shouldBeginMultiSelectAction
+		self.didBeginMultiSelectAction = didBeginMultiSelectAction
 	}
 	
 	internal var hasEditActions: Bool {

--- a/Sources/FunctionalTableData/CellActions.swift
+++ b/Sources/FunctionalTableData/CellActions.swift
@@ -227,6 +227,7 @@ public struct CellActions {
 	public typealias DeselectionAction = (_ sender: UIView) -> SelectionState
 	public typealias CanPerformAction = (_ selector: Selector) -> Bool
 	public typealias VisibilityAction = (_ cell: UIView, _ visible: Bool) -> Void
+	public typealias BeginMultiSelectAction = () -> Void
 	/// Closure type that is executed when the user 3D-touches on a cell
 	/// - parameter cell: the cell in which the 3D-touch occured
 	/// - parameter point: The point where the 3D-touch occured, translated to the coordinate space of the cell
@@ -268,6 +269,11 @@ public struct CellActions {
 	/// UIContextMenus were introduced in iOS 13. This property is not used on earlier versions of iOS.
 	public var contextMenuConfiguration: ContextMenuConfiguration?
 	
+	/// Action performed when multi list selection has begun on this cell.
+	/// This automatically enables the tableView's editing mode _before_ this closure is called.
+	/// Require's the tableview's `allowsMultipleSelectionDuringEditing` property be set to `true`.
+	public var beginMultiSelectAction: BeginMultiSelectAction?
+	
 	public init(
 		canSelectAction: CanSelectAction? = nil,
 		selectionAction: SelectionAction? = nil,
@@ -278,7 +284,8 @@ public struct CellActions {
 		canBeMoved: Bool = false,
 		visibilityAction: VisibilityAction? = nil,
 		previewingViewControllerAction: PreviewingViewControllerAction? = nil,
-		contextMenuConfiguration: ContextMenuConfiguration? = nil) {
+		contextMenuConfiguration: ContextMenuConfiguration? = nil,
+		beginMultiSelectAction: BeginMultiSelectAction? = nil) {
 		self.canSelectAction = canSelectAction
 		self.selectionAction = selectionAction
 		self.deselectionAction = deselectionAction
@@ -296,6 +303,7 @@ public struct CellActions {
 			self.previewingViewControllerAction = nil
 		}
 		self.contextMenuConfiguration = contextMenuConfiguration
+		self.beginMultiSelectAction = beginMultiSelectAction
 	}
 	
 	internal var hasEditActions: Bool {

--- a/Sources/FunctionalTableData/TableView/FunctionalTableData+UITableViewDelegate.swift
+++ b/Sources/FunctionalTableData/TableView/FunctionalTableData+UITableViewDelegate.swift
@@ -255,5 +255,25 @@ extension FunctionalTableData {
 				cellConfig.actions.contextMenuConfiguration?.previewContentCommitter?(animator.previewViewController)
 			}
 		}
+		
+		/// Requires iOS 13.0+
+		/// Whether multi selection is available when editing mode is enabled.
+		/// Based on the tableView's `allowsMultipleSelectionDuringEditing` property.
+		/// https://developer.apple.com/documentation/uikit/uitableviewdelegate/selecting_multiple_items_with_a_two-finger_pan_gesture
+		@available(iOS 13.0, *)
+		public func tableView(_ tableView: UITableView, shouldBeginMultipleSelectionInteractionAt indexPath: IndexPath) -> Bool {
+			return tableView.allowsMultipleSelectionDuringEditing
+		}
+		
+		/// Requires iOS 13.0+
+		/// Called when a multi item selection gesture has begun.
+		/// - Handler forwarded to `CellActions` via `beginMultiSelectAction`
+		@available(iOS 13.0, *)
+		public func tableView(_ tableView: UITableView, didBeginMultipleSelectionInteractionAt indexPath: IndexPath) {
+			tableView.setEditing(true, animated: true)
+			
+			let cellConfig = data.sections[indexPath]
+			cellConfig?.actions.beginMultiSelectAction?()
+		}
 	}
 }

--- a/Sources/FunctionalTableData/TableView/FunctionalTableData+UITableViewDelegate.swift
+++ b/Sources/FunctionalTableData/TableView/FunctionalTableData+UITableViewDelegate.swift
@@ -258,11 +258,14 @@ extension FunctionalTableData {
 		
 		/// Requires iOS 13.0+
 		/// Whether multi selection is available when editing mode is enabled.
-		/// Based on the tableView's `allowsMultipleSelectionDuringEditing` property.
+		/// Based on the tableView's `allowsMultipleSelectionDuringEditing` property and `CellActions`'s `shouldBeginMultiSelectAction` result.
 		/// https://developer.apple.com/documentation/uikit/uitableviewdelegate/selecting_multiple_items_with_a_two-finger_pan_gesture
 		@available(iOS 13.0, *)
 		public func tableView(_ tableView: UITableView, shouldBeginMultipleSelectionInteractionAt indexPath: IndexPath) -> Bool {
-			return tableView.allowsMultipleSelectionDuringEditing
+			let cellConfig = data.sections[indexPath]
+			
+			let shouldBeginMultiSelect = cellConfig?.actions.shouldBeginMultiSelectAction?() ?? false
+			return tableView.allowsMultipleSelectionDuringEditing && shouldBeginMultiSelect
 		}
 		
 		/// Requires iOS 13.0+
@@ -273,7 +276,7 @@ extension FunctionalTableData {
 			tableView.setEditing(true, animated: true)
 			
 			let cellConfig = data.sections[indexPath]
-			cellConfig?.actions.beginMultiSelectAction?()
+			cellConfig?.actions.didBeginMultiSelectAction?()
 		}
 	}
 }


### PR DESCRIPTION
[Apple docs](https://developer.apple.com/documentation/uikit/uitableviewdelegate/selecting_multiple_items_with_a_two-finger_pan_gesture)

---- 

This adds support for multi item selection in an FTD tableview. When the `tableView.allowsMultipleSelectionDuringEditing` is set to true, list multi selection can be initiated with a two finger swipe along the rows, or, if editing mode is already enabled, single finger swipe down the rows.

Lifecycle of this interaction is along the lines of:

- **`tableView(_:shouldBeginMultipleSelectionInteractionAt:) -> Bool`**: Determines if these gestures are available.
- **`tableView(_:didBeginMultipleSelectionInteractionAt:)`**: Called when a multi item selection gesture has begun. 
    - Handler forwarded to `CellActions` via `beginMultiSelectAction`
- **`tableView(_:didSelectRowAt:)`**: Called when a row is selected during the multi select gesture.
    - Handler forwarded to `CellActions` via `selectionAction`
- **`tableView(_:didDeselectRowAt:)`**: Called when a row is deselected during the multi select gesture.
    - Handler forwarded to `CellActions` via `deselectionAction`
- **`tableViewDidEndMultipleSelectionInteraction(_:)`**: Called when a multi item selection gesture has ended. 
    - ⚠️ This handler is **not forwarded to `CellActions`** because the API does not provide an `IndexPath`.

----

This is my first FTD PR. Let me know if I've missed anything here.