### PR TITLE
Added cell selection state to cell actions.

### DIFF
--- a/Sources/FunctionalTableData/CellActions.swift
+++ b/Sources/FunctionalTableData/CellActions.swift
@@ -227,8 +227,8 @@ public struct CellActions {
 	public typealias DeselectionAction = (_ sender: UIView) -> SelectionState
 	public typealias CanPerformAction = (_ selector: Selector) -> Bool
 	public typealias VisibilityAction = (_ cell: UIView, _ visible: Bool) -> Void
-	public typealias ShouldBeginMultiSelectAction = () -> Bool
-	public typealias DidBeginMultiSelectAction = () -> Void
+	public typealias ShouldBeginMultiSelectGestureAction = () -> Bool
+	public typealias DidBeginMultiSelectGestureAction = () -> Void
 	/// Closure type that is executed when the user 3D-touches on a cell
 	/// - parameter cell: the cell in which the 3D-touch occured
 	/// - parameter point: The point where the 3D-touch occured, translated to the coordinate space of the cell
@@ -272,12 +272,13 @@ public struct CellActions {
 	
 	/// Whether the multi select drag gesture can begin from this cell.
 	/// Also require's the tableview's `allowsMultipleSelectionDuringEditing` property be set to `true`.
-	public var shouldBeginMultiSelectAction: ShouldBeginMultiSelectAction?
+	public var shouldBeginMultiSelectGestureAction: ShouldBeginMultiSelectGestureAction?
 	
-	/// Action performed when multi list selection has begun on this cell.
+	/// Action performed when a multi list selection gesture has begun on this cell.
+	/// A multi selection gesture is either a two finger tap or scroll on the cell, or a drag gesture from the checkbox selection accessory to another cell.
 	/// This automatically enables the tableView's editing mode _before_ this closure is called.
 	/// Require's the tableview's `allowsMultipleSelectionDuringEditing` property be set to `true`.
-	public var didBeginMultiSelectAction: DidBeginMultiSelectAction?
+	public var didBeginMultiSelectGestureAction: DidBeginMultiSelectGestureAction?
 	
 	public init(
 		canSelectAction: CanSelectAction? = nil,
@@ -290,8 +291,8 @@ public struct CellActions {
 		visibilityAction: VisibilityAction? = nil,
 		previewingViewControllerAction: PreviewingViewControllerAction? = nil,
 		contextMenuConfiguration: ContextMenuConfiguration? = nil,
-		shouldBeginMultiSelectAction: ShouldBeginMultiSelectAction? = nil,
-		didBeginMultiSelectAction: DidBeginMultiSelectAction? = nil) {
+		shouldBeginMultiSelectGestureAction: ShouldBeginMultiSelectGestureAction? = nil,
+		didBeginMultiSelectGestureAction: DidBeginMultiSelectGestureAction? = nil) {
 		self.canSelectAction = canSelectAction
 		self.selectionAction = selectionAction
 		self.deselectionAction = deselectionAction
@@ -309,8 +310,8 @@ public struct CellActions {
 			self.previewingViewControllerAction = nil
 		}
 		self.contextMenuConfiguration = contextMenuConfiguration
-		self.shouldBeginMultiSelectAction = shouldBeginMultiSelectAction
-		self.didBeginMultiSelectAction = didBeginMultiSelectAction
+		self.shouldBeginMultiSelectGestureAction = shouldBeginMultiSelectGestureAction
+		self.didBeginMultiSelectGestureAction = didBeginMultiSelectGestureAction
 	}
 	
 	internal var hasEditActions: Bool {

--- a/Sources/FunctionalTableData/CellStyle.swift
+++ b/Sources/FunctionalTableData/CellStyle.swift
@@ -70,6 +70,10 @@ public struct CellStyle {
 	/// Supported by `UICollectionView` only.
 	public var masksToBounds: Bool
 	
+	/// Whether the cell is initially in a selected state when it is first displayed
+	/// Supported by `UITableView` only.
+	public var selected: Bool?
+	
 	@available(*, deprecated, message: "The `backgroundView` argument is no longer available. Use backgroundViewProvider instead.")
 	public init(topSeparator: Separator.Style? = nil,
 	            bottomSeparator: Separator.Style? = nil,
@@ -121,7 +125,8 @@ public struct CellStyle {
 				tintColor: UIColor? = nil,
 				layoutMargins: UIEdgeInsets? = nil,
 				cornerRadius: CGFloat = 0,
-				masksToBounds: Bool = true) {
+				masksToBounds: Bool = true,
+				selected: Bool? = nil) {
 		self.bottomSeparator = bottomSeparator
 		self.topSeparator = topSeparator
 		self.separatorColor = separatorColor
@@ -134,9 +139,10 @@ public struct CellStyle {
 		self.layoutMargins = layoutMargins
 		self.cornerRadius = cornerRadius
 		self.masksToBounds = masksToBounds
+		self.selected = selected
 	}
 	
-	func configure(cell: UICollectionViewCell, in collectionView: UICollectionView) {
+	func configure(cell: UICollectionViewCell, at indexPath: IndexPath, in collectionView: UICollectionView) {
 		cell.backgroundColor = backgroundColor
 		cell.backgroundView = backgroundViewProvider?.backgroundView()
 
@@ -163,7 +169,7 @@ public struct CellStyle {
 		cell.layer.masksToBounds = masksToBounds
 	}
 	
-	func configure(cell: UITableViewCell, in tableView: UITableView) {
+	func configure(cell: UITableViewCell, at indexPath: IndexPath, in tableView: UITableView) {
 		if let separator = bottomSeparator {
 			cell.applyBottomSeparator(separator, color: separatorColor)
 		} else {
@@ -200,6 +206,16 @@ public struct CellStyle {
 		}
 		
 		cell.accessoryType = accessoryType
+		switch selected {
+		case true?:
+			tableView.selectRow(at: indexPath, animated: false, scrollPosition: .none)
+			cell.isSelected = true
+		case false?:
+			tableView.deselectRow(at: indexPath, animated: false)
+			cell.isSelected = false
+		case .none:
+			break
+		}
 	}
 }
 
@@ -217,6 +233,7 @@ extension CellStyle: Equatable {
 		equality = equality && lhs.cornerRadius == rhs.cornerRadius
 		equality = equality && lhs.masksToBounds == rhs.masksToBounds
 		equality = equality && lhs.backgroundViewProvider?.isEqualTo(rhs.backgroundViewProvider) ?? (rhs.backgroundViewProvider == nil)
+		equality = equality && lhs.selected == rhs.selected
 		return equality
 	}
 }

--- a/Sources/FunctionalTableData/CollectionView/FunctionalCollectionData+UICollectionViewDataSource.swift
+++ b/Sources/FunctionalTableData/CollectionView/FunctionalCollectionData+UICollectionViewDataSource.swift
@@ -33,7 +33,7 @@ extension FunctionalCollectionData {
 			cellConfig.accessibility.with(defaultIdentifier: accessibilityIdentifier).apply(to: cell)
 			cellConfig.update(cell: cell, in: collectionView)
 			let style = cellConfig.style ?? CellStyle()
-			style.configure(cell: cell, in: collectionView)
+			style.configure(cell: cell, at: indexPath, in: collectionView)
 			
 			return cell
 		}

--- a/Sources/FunctionalTableData/CollectionView/FunctionalCollectionData.swift
+++ b/Sources/FunctionalTableData/CollectionView/FunctionalCollectionData.swift
@@ -287,7 +287,7 @@ public class FunctionalCollectionData {
 					
 					let section = sections[update.index.section]
 					let style = section.mergedStyle(for: update.index.item)
-					style.configure(cell: cell, in: collectionView)
+					style.configure(cell: cell, at: update.index, in: collectionView)
 				}
 			}
 		}

--- a/Sources/FunctionalTableData/TableView/FunctionalTableData+Cells.swift
+++ b/Sources/FunctionalTableData/TableView/FunctionalTableData+Cells.swift
@@ -47,7 +47,7 @@ extension FunctionalTableData {
 			let section = data.sections[indexPath.section]
 			cellConfig.update(cell: cell, in: tableView)
 			let style = section.mergedStyle(for: indexPath.row)
-			style.configure(cell: cell, in: tableView)
+			style.configure(cell: cell, at: indexPath, in: tableView)
 			if cell.isHighlighted == false, let highlightedRow = highlightedRow, highlightedRow == KeyPath(sectionKey: section.key, rowKey: cellConfig.key) {
 				cell.isHighlighted = true
 			}

--- a/Sources/FunctionalTableData/TableView/FunctionalTableData+UITableViewDataSource.swift
+++ b/Sources/FunctionalTableData/TableView/FunctionalTableData+UITableViewDataSource.swift
@@ -54,7 +54,7 @@ extension FunctionalTableData {
 		
 		public func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
 			guard let cellConfig = data.sections[indexPath] else { return false }
-			return cellConfig.actions.hasEditActions || self.tableView(tableView, canMoveRowAt: indexPath)
+			return cellConfig.actions.hasEditActions || self.tableView(tableView, canMoveRowAt: indexPath) || cellConfig.style?.selected != nil
 		}
 	}
 }

--- a/Sources/FunctionalTableData/TableView/FunctionalTableData+UITableViewDelegate.swift
+++ b/Sources/FunctionalTableData/TableView/FunctionalTableData+UITableViewDelegate.swift
@@ -264,7 +264,7 @@ extension FunctionalTableData {
 		public func tableView(_ tableView: UITableView, shouldBeginMultipleSelectionInteractionAt indexPath: IndexPath) -> Bool {
 			let cellConfig = data.sections[indexPath]
 			
-			let shouldBeginMultiSelect = cellConfig?.actions.shouldBeginMultiSelectAction?() ?? false
+			let shouldBeginMultiSelect = cellConfig?.actions.shouldBeginMultiSelectGestureAction?() ?? false
 			return tableView.allowsMultipleSelectionDuringEditing && shouldBeginMultiSelect
 		}
 		
@@ -276,7 +276,7 @@ extension FunctionalTableData {
 			tableView.setEditing(true, animated: true)
 			
 			let cellConfig = data.sections[indexPath]
-			cellConfig?.actions.didBeginMultiSelectAction?()
+			cellConfig?.actions.didBeginMultiSelectGestureAction?()
 		}
 	}
 }

--- a/Tests/FunctionalTableDataTests/CellStyleTests.swift
+++ b/Tests/FunctionalTableDataTests/CellStyleTests.swift
@@ -10,9 +10,13 @@ import XCTest
 @testable import FunctionalTableData
 
 class StyleTests: XCTestCase {
-	var cell: UITableViewCell!
-	var table: UITableView!
-	var style: CellStyle!
+
+	static let indexPath = IndexPath(row: 0, section: 0)
+	
+	var tableData: FunctionalTableData!
+	var tableView: UITableView!
+	var cell: TestCaseCell!
+	var viewCell: UITableViewCell!
 
 	struct ColoredBackgroundProvider: BackgroundViewProvider {
 		let color: UIColor
@@ -31,147 +35,169 @@ class StyleTests: XCTestCase {
 	
 	override func setUp() {
 		super.setUp()
-		cell = UITableViewCell()
-		table = UITableView()
-		style = CellStyle()
+		cell = TestCaseCell(key: "first", style: CellStyle(), state: TestCaseState(data: "first"), cellUpdater: TestCaseState.updateView)
+		tableData = FunctionalTableData()
+		tableView = UITableView()
+		tableData.tableView = tableView
+		applyStyle()
 	}
 	
 	override func tearDown() {
 		super.tearDown()
+		tableData = nil
+		tableView = nil
 		cell = nil
-		table = nil
-		style = nil
+		viewCell = nil
+	}
+	
+	func applyStyle() {
+		let expectation1 = expectation(description: "applyStyle")
+		tableData.renderAndDiff([TableSection(key: "first", rows: [cell])], animated: false) { [weak self] in
+			guard let self = self else { return }
+			self.viewCell = self.tableView.dataSource?.tableView(self.tableView, cellForRowAt: Self.indexPath)
+			self.viewCell.layoutIfNeeded()
+			expectation1.fulfill()
+		}
+		wait(for: [expectation1], timeout: 1000)
 	}
 	
 	func testBottomSeparator() {
-		style.bottomSeparator = .full
-		style.configure(cell: cell, in: table)
-		var separator = cell.viewWithTag(Separator.Tag.bottom.rawValue)
-		cell.layoutIfNeeded()
+		cell.style?.bottomSeparator = .full
+		applyStyle()
+		var separator = viewCell.viewWithTag(Separator.Tag.bottom.rawValue)
 		XCTAssertNotNil(separator)
-		XCTAssertEqual(separator!.bounds.width, cell.bounds.width)
+		XCTAssertEqual(separator!.bounds.width, viewCell.bounds.width)
 		
-		style.bottomSeparator = .inset
-		style.configure(cell: cell, in: table)
-		separator = cell.viewWithTag(Separator.Tag.bottom.rawValue)
-		cell.layoutIfNeeded()
+		cell.style?.bottomSeparator = .inset
+		applyStyle()
+		separator = viewCell.viewWithTag(Separator.Tag.bottom.rawValue)
 		XCTAssertNotNil(separator)
-		XCTAssertEqual(separator!.bounds.width, cell.bounds.width - cell.layoutMarginsGuide.layoutFrame.minX)
+		XCTAssertEqual(separator!.bounds.width, viewCell.bounds.width - viewCell.layoutMarginsGuide.layoutFrame.minX)
 		
-		style.bottomSeparator = nil
-		style.configure(cell: cell, in: table)
-		separator = cell.viewWithTag(Separator.Tag.bottom.rawValue)
+		cell.style?.bottomSeparator = nil
+		applyStyle()
+		separator = viewCell.viewWithTag(Separator.Tag.bottom.rawValue)
 		XCTAssertNil(separator)
 	}
 	
 	func testCustomBottomSeparator() {
-		style.bottomSeparator = Separator.Style(leadingInset: .init(value: 10, respectingLayoutMargins: false), trailingInset: .none, thickness: 20)
-		style.configure(cell: cell, in: table)
-		let separator = cell.viewWithTag(Separator.Tag.bottom.rawValue)
-		cell.layoutIfNeeded()
+		cell.style?.bottomSeparator = Separator.Style(leadingInset: .init(value: 10, respectingLayoutMargins: false), trailingInset: .none, thickness: 20)
+		applyStyle()
+		let separator = viewCell.viewWithTag(Separator.Tag.bottom.rawValue)
 		XCTAssertNotNil(separator)
-		XCTAssertEqual(separator!.bounds.width, cell.bounds.width - 10)
+		XCTAssertEqual(separator!.bounds.width, viewCell.bounds.width - 10)
 		XCTAssertEqual(separator!.bounds.height, 20)
 	}
 	
 	func testTopSeparator() {
-		style.topSeparator = .full
-		style.configure(cell: cell, in: table)
-		var separator = cell.viewWithTag(Separator.Tag.top.rawValue)
-		cell.layoutIfNeeded()
+		cell.style?.topSeparator = .full
+		applyStyle()
+		var separator = viewCell.viewWithTag(Separator.Tag.top.rawValue)
 		XCTAssertNotNil(separator)
-		XCTAssertEqual(separator!.bounds.width, cell.bounds.width)
+		XCTAssertEqual(separator!.bounds.width, viewCell.bounds.width)
 		
-		style.topSeparator = .inset
-		style.configure(cell: cell, in: table)
-		separator = cell.viewWithTag(Separator.Tag.top.rawValue)
-		cell.layoutIfNeeded()
+		cell.style?.topSeparator = .inset
+		applyStyle()
+		separator = viewCell.viewWithTag(Separator.Tag.top.rawValue)
 		XCTAssertNotNil(separator)
-		XCTAssertEqual(separator!.bounds.width, cell.bounds.width - cell.layoutMarginsGuide.layoutFrame.minX)
+		XCTAssertEqual(separator!.bounds.width, viewCell.bounds.width - viewCell.layoutMarginsGuide.layoutFrame.minX)
 		
-		style.topSeparator = nil
-		style.configure(cell: cell, in: table)
-		separator = cell.viewWithTag(Separator.Tag.top.rawValue)
+		cell.style?.topSeparator = nil
+		applyStyle()
+		separator = viewCell.viewWithTag(Separator.Tag.top.rawValue)
 		XCTAssertNil(separator)
 	}
 	
 	func testCustomTopSeparator() {
-		style.topSeparator = Separator.Style(leadingInset: .init(value: 10, respectingLayoutMargins: false), trailingInset: .none, thickness: 20)
-		style.configure(cell: cell, in: table)
-		let separator = cell.viewWithTag(Separator.Tag.top.rawValue)
-		cell.layoutIfNeeded()
+		cell.style?.topSeparator = Separator.Style(leadingInset: .init(value: 10, respectingLayoutMargins: false), trailingInset: .none, thickness: 20)
+		applyStyle()
+		let separator = viewCell.viewWithTag(Separator.Tag.top.rawValue)
 		XCTAssertNotNil(separator)
-		XCTAssertEqual(separator!.bounds.width, cell.bounds.width - 10)
+		XCTAssertEqual(separator!.bounds.width, viewCell.bounds.width - 10)
 		XCTAssertEqual(separator!.bounds.height, 20)
 	}
 	
 	func testHighlight() {
-		style.highlight = true
-		style.configure(cell: cell, in: table)
-		XCTAssertEqual(cell.selectionStyle, .default)
-		style.highlight = false
-		style.configure(cell: cell, in: table)
-		XCTAssertEqual(cell.selectionStyle, .none)
-		style.highlight = nil
-		style.configure(cell: cell, in: table)
-		XCTAssertEqual(cell.selectionStyle, .none)
+		cell.style?.highlight = true
+		applyStyle()
+		XCTAssertEqual(viewCell.selectionStyle, .default)
+		cell.style?.highlight = false
+		applyStyle()
+		XCTAssertEqual(viewCell.selectionStyle, .none)
+		cell.style?.highlight = nil
+		applyStyle()
+		XCTAssertEqual(viewCell.selectionStyle, .none)
 	}
 	
 	func testAccessoryType() {
-		style.accessoryType = .disclosureIndicator
-		style.configure(cell: cell, in: table)
-		XCTAssertEqual(cell.accessoryType, .disclosureIndicator)
-		style.accessoryType = .checkmark
-		style.configure(cell: cell, in: table)
-		XCTAssertEqual(cell.accessoryType, .checkmark)
-		style.accessoryType = .none
-		style.configure(cell: cell, in: table)
-		XCTAssertEqual(cell.accessoryType, .none)
+		cell.style?.accessoryType = .disclosureIndicator
+		applyStyle()
+		XCTAssertEqual(viewCell.accessoryType, .disclosureIndicator)
+		cell.style?.accessoryType = .checkmark
+		applyStyle()
+		XCTAssertEqual(viewCell.accessoryType, .checkmark)
+		cell.style?.accessoryType = .none
+		applyStyle()
+		XCTAssertEqual(viewCell.accessoryType, .none)
 	}
 	
 	func testSelectionColor() {
-		style.selectionColor = .red
-		style.configure(cell: cell, in: table)
-		XCTAssertEqual(.red, cell.selectedBackgroundView?.backgroundColor)
-		style.selectionColor = nil
-		style.configure(cell: cell, in: table)
-		XCTAssertNil(cell.selectedBackgroundView?.backgroundColor)
+		cell.style?.selectionColor = .red
+		applyStyle()
+		XCTAssertEqual(.red, viewCell.selectedBackgroundView?.backgroundColor)
+		cell.style?.selectionColor = nil
+		applyStyle()
+		XCTAssertNil(viewCell.selectedBackgroundView?.backgroundColor)
 	}
 	
 	func testBackground() {
-		style.configure(cell: cell, in: table)
-		XCTAssertEqual(cell.backgroundColor, CellStyle.defaultBackgroundColor)
-		style.backgroundColor = .red
-		style.configure(cell: cell, in: table)
-		XCTAssertEqual(cell.backgroundColor, .red)
+		applyStyle()
+		XCTAssertEqual(viewCell.backgroundColor, CellStyle.defaultBackgroundColor)
+		cell.style?.backgroundColor = .red
+		applyStyle()
+		XCTAssertEqual(viewCell.backgroundColor, .red)
 		let backgroundViewProvider = ColoredBackgroundProvider(color: .yellow)
-		style.backgroundViewProvider = backgroundViewProvider
-		style.configure(cell: cell, in: table)
-		XCTAssertEqual(cell.backgroundView?.backgroundColor, .yellow)
-		style.backgroundViewProvider = nil
-		style.backgroundColor = nil
-		style.configure(cell: cell, in: table)
-		XCTAssertNil(cell.backgroundColor)
-		XCTAssertNil(cell.backgroundView?.backgroundColor)
+		cell.style?.backgroundViewProvider = backgroundViewProvider
+		applyStyle()
+		XCTAssertEqual(viewCell.backgroundView?.backgroundColor, .yellow)
+		cell.style?.backgroundViewProvider = nil
+		cell.style?.backgroundColor = nil
+		applyStyle()
+		XCTAssertNil(viewCell.backgroundColor)
+		XCTAssertNil(viewCell.backgroundView?.backgroundColor)
 	}
 	
 	func testTintColor() {
-		let ogTint = cell.tintColor
-		style.tintColor = .red
-		style.configure(cell: cell, in: table)
-		XCTAssertEqual(cell.tintColor, .red)
-		style.tintColor = nil
-		style.configure(cell: cell, in: table)
-		XCTAssertEqual(cell.tintColor, ogTint)
+		let ogTint = viewCell.tintColor
+		cell.style?.tintColor = .red
+		applyStyle()
+		XCTAssertEqual(viewCell.tintColor, .red)
+		cell.style?.tintColor = nil
+		applyStyle()
+		XCTAssertEqual(viewCell.tintColor, ogTint)
 	}
 	
 	func testLayoutMargin() {
 		let margins = UIEdgeInsets(top: 13, left: 13, bottom: 13, right: 13)
-		style.layoutMargins = margins
-		style.configure(cell: cell, in: table)
-		XCTAssertEqual(cell.contentView.layoutMargins, margins)
-		style.layoutMargins = nil
-		style.configure(cell: cell, in: table)
-		XCTAssertEqual(cell.contentView.layoutMargins, UIView().layoutMargins)
+		cell.style?.layoutMargins = margins
+		applyStyle()
+		XCTAssertEqual(viewCell.contentView.layoutMargins, margins)
+		cell.style?.layoutMargins = nil
+		applyStyle()
+		XCTAssertEqual(viewCell.contentView.layoutMargins, UIView().layoutMargins)
+	}
+	
+	func testSelected() {
+		cell.style?.selected = true
+		applyStyle()
+		XCTAssertEqual(viewCell.isSelected, true)
+		XCTAssertTrue(tableView.indexPathForSelectedRow == Self.indexPath)
+		XCTAssertTrue(tableView.indexPathsForSelectedRows?.contains(Self.indexPath) == true)
+		cell.style?.selected = false
+		applyStyle()
+		XCTAssertEqual(viewCell.isSelected, false)
+		XCTAssertTrue(tableView.indexPathForSelectedRow == nil)
+		XCTAssertTrue(tableView.indexPathsForSelectedRows == nil)
+
 	}
 }


### PR DESCRIPTION
`UITableViewCell` has a selected property, which is automatically toggled through the UITableView in many cases. For example, if a user taps on a cell it is first highlighted then selected. If a user swipes on a cell, then the table view determines that that cell is now selected and shows the leading or trailing swipe actions accordingly.

If the table view supports multi-selection, then the table view shows checkboxes as a left accessory view of the cell, and if a cell is selected (via either a double-finger swipe gesture or a single tap), then its index path is added to `indexPathsForSelectedRows` automatically. 

If, however, the tableView is reloaded, or simply displaying for the first time and we want certain cells pre-selected, then `indexPathsForSelectedRows` is reset to nil. Therefore, it isn't a reliable way of keeping track of which rows are selected. `selected: Bool?` in `CellStyle` fixes this and now whenever the table view is rendered or its data is reloaded (pull-to-refresh, pagination, etc), the selections are not lost. 

In the same vein, just like how the table view needs to be in editing mode for multi-select to work, the function `public func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool` is called on `UITableViewDataSource` to confirm that an individual cell *can* have a checkbox in multi-select mode. Therefore, `selected` is checked in the internal `hasEditActions` computed property to make sure that the right cells can be selected and deselected.