### PR TITLE
Unhighlight cell on deselection.

### DIFF
--- a/Sources/FunctionalTableData/TableView/FunctionalTableData+UITableViewDelegate.swift
+++ b/Sources/FunctionalTableData/TableView/FunctionalTableData+UITableViewDelegate.swift
@@ -136,6 +136,11 @@ extension FunctionalTableData {
 			guard let cell = tableView.cellForRow(at: indexPath) else { return }
 			let cellConfig = data.sections[indexPath]
 			
+			let keyPath = data.sections.itemPath(from: indexPath)
+			if cellStyler.highlightedRow == keyPath {
+				self.cellStyler.highlightRow(at: nil, animated: false, in: tableView)
+			}
+			
 			let selectionState = cellConfig?.actions.deselectionAction?(cell) ?? .deselected
 			if selectionState == .selected {
 				DispatchQueue.main.async {


### PR DESCRIPTION
Because of our custom selection logic for `UITableView`, cells that are selected are usually also highlighted using `CellStyler`.
The problem comes when gestures are used for multi-selection, or accessory view are tapped when in multi-selection, the last selected cell is always set as the highlighted cell. When using gestures or tapping the accessory view, the normal flow of `shouldHighlightCellAt` is not called, meaning that the cell does not properly un-highlight.
This PR simply adds logic to say: when a cell is de-selected, if it is still highlighted, unhighlight it.
In almost all cases except multi-select, this would have no effect because the cell is highlighted and un-highlighted before it is selected or de-selected.