### PR TITLE
Remove redundant call to tableView.setEditing(_:animated:)

### DIFF
--- a/Sources/FunctionalTableData/TableView/FunctionalTableData+UITableViewDelegate.swift
+++ b/Sources/FunctionalTableData/TableView/FunctionalTableData+UITableViewDelegate.swift
@@ -278,8 +278,6 @@ extension FunctionalTableData {
 		/// - Handler forwarded to `CellActions` via `beginMultiSelectAction`
 		@available(iOS 13.0, *)
 		public func tableView(_ tableView: UITableView, didBeginMultipleSelectionInteractionAt indexPath: IndexPath) {
-			tableView.setEditing(true, animated: true)
-			
 			let cellConfig = data.sections[indexPath]
 			cellConfig?.actions.didBeginMultiSelectGestureAction?()
 		}


### PR DESCRIPTION
In order for `tableView(_:, didBeginMultipleSelectionInteractionAt:)` to be called, editing mode needs to be enabled on the tableView. This removes that redundant, and potentially costly (in terms of performance), call to setting and animating the tableView to editing mode.