### PR TITLE
Use NSDiffableDataSource for iOS 13 or greater

### DIFF
--- a/FunctionalTableData.xcodeproj/project.pbxproj
+++ b/FunctionalTableData.xcodeproj/project.pbxproj
@@ -52,6 +52,11 @@
 		6C27C0C02372014100EA73F9 /* TableSectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C27C0AB2372008900EA73F9 /* TableSectionTests.swift */; };
 		6CB4D378246B904B00BFD647 /* AccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CB4D377246B904B00BFD647 /* AccessibilityTests.swift */; };
 		6CEFBC462458902400E6AF19 /* Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CEFBC452458902400E6AF19 /* Accessibility.swift */; };
+		EC42534926025A2A00EDE934 /* DiffableDataSourceTableCellReuseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC42534626025A2A00EDE934 /* DiffableDataSourceTableCellReuseTests.swift */; };
+		EC42534A26025A2A00EDE934 /* DiffableDataSourceFunctionalDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC42534726025A2A00EDE934 /* DiffableDataSourceFunctionalDataTests.swift */; };
+		EC42534B26025A2A00EDE934 /* DiffableDataSourceFunctionalTableDataPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC42534826025A2A00EDE934 /* DiffableDataSourceFunctionalTableDataPerformanceTests.swift */; };
+		ECE4BD6C2613AD0D00BCAB6E /* FunctionalTableData+DiffableDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECE4BD6B2613AD0D00BCAB6E /* FunctionalTableData+DiffableDataSource.swift */; };
+		ECE4BD702613B1C900BCAB6E /* FunctionalTableData+Classic.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECE4BD6F2613B1C900BCAB6E /* FunctionalTableData+Classic.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -113,6 +118,11 @@
 		6C27C0B6237200DC00EA73F9 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		6CB4D377246B904B00BFD647 /* AccessibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityTests.swift; sourceTree = "<group>"; };
 		6CEFBC452458902400E6AF19 /* Accessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Accessibility.swift; sourceTree = "<group>"; };
+		EC42534626025A2A00EDE934 /* DiffableDataSourceTableCellReuseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiffableDataSourceTableCellReuseTests.swift; sourceTree = "<group>"; };
+		EC42534726025A2A00EDE934 /* DiffableDataSourceFunctionalDataTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiffableDataSourceFunctionalDataTests.swift; sourceTree = "<group>"; };
+		EC42534826025A2A00EDE934 /* DiffableDataSourceFunctionalTableDataPerformanceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiffableDataSourceFunctionalTableDataPerformanceTests.swift; sourceTree = "<group>"; };
+		ECE4BD6B2613AD0D00BCAB6E /* FunctionalTableData+DiffableDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FunctionalTableData+DiffableDataSource.swift"; sourceTree = "<group>"; };
+		ECE4BD6F2613B1C900BCAB6E /* FunctionalTableData+Classic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FunctionalTableData+Classic.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -186,6 +196,9 @@
 		6C27C0552371FFB000EA73F9 /* FunctionalTableDataTests */ = {
 			isa = PBXGroup;
 			children = (
+				EC42534726025A2A00EDE934 /* DiffableDataSourceFunctionalDataTests.swift */,
+				EC42534826025A2A00EDE934 /* DiffableDataSourceFunctionalTableDataPerformanceTests.swift */,
+				EC42534626025A2A00EDE934 /* DiffableDataSourceTableCellReuseTests.swift */,
 				6CB4D377246B904B00BFD647 /* AccessibilityTests.swift */,
 				6C27C0A72372008900EA73F9 /* CellStyleTests.swift */,
 				6C27C0A42372008900EA73F9 /* FunctionalDataTests.swift */,
@@ -235,6 +248,8 @@
 				6C27C07C2372007B00EA73F9 /* FunctionalTableData+UITableViewDataSource.swift */,
 				6C27C07D2372007B00EA73F9 /* TableItemConfigType.swift */,
 				6C27C07E2372007B00EA73F9 /* UITableView+Reusable.swift */,
+				ECE4BD6B2613AD0D00BCAB6E /* FunctionalTableData+DiffableDataSource.swift */,
+				ECE4BD6F2613B1C900BCAB6E /* FunctionalTableData+Classic.swift */,
 			);
 			path = TableView;
 			sourceTree = "<group>";
@@ -380,10 +395,12 @@
 				6C27C08B2372007B00EA73F9 /* UIView+Extensions.swift in Sources */,
 				6C27C08E2372007B00EA73F9 /* BackgroundViewProvider.swift in Sources */,
 				6CEFBC462458902400E6AF19 /* Accessibility.swift in Sources */,
+				ECE4BD6C2613AD0D00BCAB6E /* FunctionalTableData+DiffableDataSource.swift in Sources */,
 				6C27C09F2372007B00EA73F9 /* Reusable.swift in Sources */,
 				6C27C09C2372007B00EA73F9 /* TableItemConfigType.swift in Sources */,
 				6C27C09E2372007B00EA73F9 /* TableData.swift in Sources */,
 				6C27C0992372007B00EA73F9 /* TableCell.swift in Sources */,
+				ECE4BD702613B1C900BCAB6E /* FunctionalTableData+Classic.swift in Sources */,
 				6C27C0982372007B00EA73F9 /* FunctionalTableData+UITableViewDelegate.swift in Sources */,
 				6C27C0852372007B00EA73F9 /* CollectionCell.swift in Sources */,
 				6C27C09B2372007B00EA73F9 /* FunctionalTableData+UITableViewDataSource.swift in Sources */,
@@ -400,7 +417,10 @@
 				6C27C0BA2372014100EA73F9 /* FunctionalTableDataDelegateTests.swift in Sources */,
 				6C27C0BC2372014100EA73F9 /* TableCellReuseTests.swift in Sources */,
 				6C27C0B92372014100EA73F9 /* FunctionalDataTests.swift in Sources */,
+				EC42534B26025A2A00EDE934 /* DiffableDataSourceFunctionalTableDataPerformanceTests.swift in Sources */,
+				EC42534926025A2A00EDE934 /* DiffableDataSourceTableCellReuseTests.swift in Sources */,
 				6C27C0BE2372014100EA73F9 /* TableSectionStyleTests.swift in Sources */,
+				EC42534A26025A2A00EDE934 /* DiffableDataSourceFunctionalDataTests.swift in Sources */,
 				6C27C0BB2372014100EA73F9 /* FunctionaltableDataPerformanceTests.swift in Sources */,
 				6C27C0C02372014100EA73F9 /* TableSectionTests.swift in Sources */,
 				6C27C0B82372014100EA73F9 /* CellStyleTests.swift in Sources */,

--- a/Sources/FunctionalTableData/CellConfigType.swift
+++ b/Sources/FunctionalTableData/CellConfigType.swift
@@ -63,3 +63,82 @@ public extension CellConfigType {
 		return type(of: self) == type(of: other)
 	}
 }
+
+public struct AnyCellConfigType: CellConfigType, Hashable {
+
+	public static func ==(lhs: AnyCellConfigType, rhs: AnyCellConfigType) -> Bool {
+		return lhs.sectionKey == rhs.sectionKey && lhs.key == rhs.key 
+	}
+	
+	public var key: String {
+		return base.key
+	}
+	
+	public var style: CellStyle? {
+		get { return base.style }
+		set { base.style = newValue }
+	}
+	
+	public var actions: CellActions {
+		get { return base.actions }
+		set { base.actions = newValue }
+	}
+	
+	public var accessibility: Accessibility {
+		get { return base.accessibility }
+		set { base.accessibility = newValue }
+	}
+	
+	public var base: CellConfigType
+	private let sectionKey: String
+	
+	init(_ base: CellConfigType, sectionKey: String) {
+		self.base = base
+		self.sectionKey = sectionKey
+	}
+	
+	public init(_ base: CellConfigType) {
+		self.init(base, sectionKey: "")
+	}
+	
+	public func hash(into hasher: inout Hasher) {
+		hasher.combine(key)
+		hasher.combine(sectionKey)
+		hasher.combine(style)
+	}
+	
+	public func dequeueCell(from tableView: UITableView, at indexPath: IndexPath) -> UITableViewCell {
+		return base.dequeueCell(from: tableView, at: indexPath)
+	}
+	
+	public func update(cell: UITableViewCell, in tableView: UITableView) {
+		base.update(cell: cell, in: tableView)
+	}
+	
+	public func update(cell: UICollectionViewCell, in collectionView: UICollectionView) {
+		base.update(cell: cell, in: collectionView)
+	}
+	
+	public func isEqual(_ other: CellConfigType) -> Bool {
+		guard let other = other as? AnyCellConfigType else { return false }
+		return sectionKey == other.sectionKey && key == other.key
+	}
+	
+	public func isSameKind(as other: CellConfigType) -> Bool {
+		return base.isSameKind(as: other)
+	}
+	
+	public func debugInfo() -> [String : Any] {
+		return base.debugInfo()
+	}
+	
+	public func register(with tableView: UITableView) {
+		base.register(with: tableView)
+	}
+	
+	public func register(with collectionView: UICollectionView) {
+		base.register(with: collectionView)
+	}
+	
+	
+}

--- a/Sources/FunctionalTableData/CellStyle.swift
+++ b/Sources/FunctionalTableData/CellStyle.swift
@@ -248,3 +248,19 @@ extension CellStyle: Equatable {
 		return equality
 	}
 }
+
+extension CellStyle: Hashable {
+	public func hash(into hasher: inout Hasher) {
+		hasher.combine(bottomSeparator)
+		hasher.combine(topSeparator)
+		hasher.combine(separatorColor)
+		hasher.combine(highlight)
+		hasher.combine(accessoryType)
+		hasher.combine(selectionColor)
+		hasher.combine(backgroundColor)
+		hasher.combine(tintColor)
+		hasher.combine(cornerRadius)
+		hasher.combine(masksToBounds)
+		hasher.combine(selected)
+	}
+}

--- a/Sources/FunctionalTableData/Separator.swift
+++ b/Sources/FunctionalTableData/Separator.swift
@@ -15,9 +15,9 @@ import UIKit
 /// Supported by `UITableView` only.
 public class Separator: UIView {
 	/// The style for table cells used as separators.
-	public struct Style: Equatable {
+	public struct Style: Equatable, Hashable {
 		/// The inset used in the separators.
-		public struct Inset: Equatable {
+		public struct Inset: Equatable, Hashable {
 			/// Specifies the amount of spacing to apply to the separator.
 			public let value: CGFloat
 			/// Specifies if the inset is relative to the layout margins.

--- a/Sources/FunctionalTableData/TableSection.swift
+++ b/Sources/FunctionalTableData/TableSection.swift
@@ -114,8 +114,8 @@ public struct TableSection: Sequence, TableSectionType {
 	}
 }
 
-public struct SectionStyle: Equatable {
-	public struct Separators: Equatable {
+public struct SectionStyle: Equatable, Hashable {
+	public struct Separators: Equatable, Hashable {
 		public static let `default` = Separators(top: .full, bottom: .full, interitem: .inset)
 		public static let topAndBottom = Separators(top: .full, bottom: .full, interitem: nil)
 		public static let full = Separators(top: .full, bottom: .full, interitem: .full)
@@ -194,3 +194,27 @@ private func isEqual(lhs: [CellConfigType], rhs: [CellConfigType]) -> Bool {
 		return leftCell.isEqual(rightCell)
 	}
 }
+
+struct DiffableTableSection: Equatable, Hashable {
+	static func ==(lhs: DiffableTableSection, rhs: DiffableTableSection) -> Bool {
+		return lhs.key == rhs.key
+	}
+	
+	let tableSection: TableSection
+	var key: String { tableSection.key }
+	
+	var anyRows: [AnyCellConfigType] {
+		return tableSection.rows.map { AnyCellConfigType($0, sectionKey: key) }
+	}
+	
+	init(_ section: TableSection) {
+		self.tableSection = section
+	}
+	
+	public func hash(into hasher: inout Hasher) {
+		hasher.combine(key)
+		hasher.combine(tableSection.style)
+	}
+}
+
+

--- a/Sources/FunctionalTableData/TableSectionHeaderFooter.swift
+++ b/Sources/FunctionalTableData/TableSectionHeaderFooter.swift
@@ -27,6 +27,10 @@ public protocol TableHeaderFooterStateType: Equatable {
 }
 
 public struct TableSectionHeaderFooter<ViewType: UIView, Layout: TableItemLayout, S: TableHeaderFooterStateType>: TableHeaderFooterConfigType {
+	public func dequeueCell(from tableView: UITableView, at indexPath: IndexPath) -> UITableViewCell {
+		return UITableViewCell()
+	}
+	
 	public typealias ViewUpdater = (_ header: TableHeaderFooter<ViewType, Layout>, _ state: S) -> Void
 	public let state: S?
 	let updateView: ViewUpdater?

--- a/Sources/FunctionalTableData/TableView/FunctionalTableData+Classic.swift
+++ b/Sources/FunctionalTableData/TableView/FunctionalTableData+Classic.swift
@@ -1,0 +1,209 @@
+//
+//  FunctionalTableData+Classic.swift
+//  FunctionalTableData
+//
+//  Created by Jason Kemp on 2021-03-30.
+//  Copyright © 2021 Shopify. All rights reserved.
+//
+
+import UIKit
+
+extension FunctionalTableData {
+	class ClassicFunctionalTableDataImpl: FunctionalTableDataImpl {
+		func renderAndDiff(_ newSections: [TableSection], animated: Bool, animations: FunctionalTableData.TableAnimations, completion: (() -> Void)?) {
+			let blockOperation = BlockOperation { [weak self] in
+				guard let strongSelf = self else {
+					if let completion = completion {
+						DispatchQueue.main.async(execute: completion)
+					}
+					return
+				}
+				
+				
+				NSException.catchAndRethrow({
+					newSections.validateKeyUniqueness(senderName: strongSelf.name)
+				}, failure: {
+					if $0.name == NSExceptionName.internalInconsistencyException {
+						guard let exceptionHandler = FunctionalTableData.exceptionHandler else { return }
+						let changes = TableSectionChangeSet()
+						let viewFrame = DispatchQueue.main.sync { strongSelf.tableView?.frame ?? .zero }
+						let exception = Exception(name: $0.name.rawValue, newSections: newSections, oldSections: strongSelf.dataSource.data.sections, changes: changes, visible: [], viewFrame: viewFrame, reason: $0.reason, userInfo: $0.userInfo)
+						exceptionHandler.handle(exception: exception)
+					}
+				})
+				
+				strongSelf.doRenderAndDiff(newSections, animated: animated, animations: animations, completion: completion)
+			}
+			//cancel waiting operations since only the last state needs to be rendered
+			renderAndDiffQueue.operations.lazy.filter { !$0.isExecuting }.forEach { $0.cancel() }
+			renderAndDiffQueue.addOperation(blockOperation)
+		}
+		private let name: String
+		private let dataSource: DataSource
+		private let renderAndDiffQueue: OperationQueue
+		var tableView: UITableView? {
+			didSet {
+				guard let tableView = tableView else { return }
+				tableView.dataSource = dataSource
+			}
+		}
+		
+		var isRendering: Bool {
+			renderAndDiffQueue.isSuspended
+		}
+		private let unitTesting: Bool
+		
+		init(name: String, cellStyler: CellStyler) {
+			self.name = name
+			dataSource = DataSource(cellStyler: cellStyler)
+			unitTesting = NSClassFromString("XCTestCase") != nil
+			renderAndDiffQueue = OperationQueue()
+			renderAndDiffQueue.name = name
+			renderAndDiffQueue.maxConcurrentOperationCount = 1
+		}
+		
+		private func doRenderAndDiff(_ newSections: [TableSection], animated: Bool, animations: TableAnimations, completion: (() -> Void)?) {
+			guard let tableView = tableView else {
+				if let completion = completion {
+					DispatchQueue.main.async(execute: completion)
+				}
+				return
+			}
+			let oldSections = dataSource.data.sections
+			
+			let visibleIndexPaths = DispatchQueue.main.sync {
+				tableView.indexPathsForVisibleRows?.filter {
+					let section = oldSections[$0.section]
+					return $0.row < section.rows.count
+				} ?? []
+			}
+			
+			let localSections = newSections.filter { $0.rows.count > 0 }
+			let changes = calculateTableChanges(oldSections: oldSections, newSections: localSections, visibleIndexPaths: visibleIndexPaths)
+			
+			// Use dispatch_sync because the table updates have to be processed before this function returns
+			// or another queued renderAndDiff could get the incorrect state to diff against.
+			DispatchQueue.main.sync { [weak self] in
+				guard let strongSelf = self else {
+					completion?()
+					return
+				}
+				
+				strongSelf.renderAndDiffQueue.isSuspended = true
+				tableView.registerCellsForSections(localSections)
+				if oldSections.isEmpty || changes.count > FunctionalTableData.reloadEntireTableThreshold || tableView.isDecelerating || !animated {
+					strongSelf.dataSource.data.sections = localSections
+					CATransaction.begin()
+					CATransaction.setCompletionBlock {
+						strongSelf.finishRenderAndDiff()
+						completion?()
+					}
+					tableView.reloadData()
+					CATransaction.commit()
+				} else {
+					if strongSelf.unitTesting {
+						strongSelf.applyTableChanges(changes, localSections: localSections, animations: animations, completion: {
+							strongSelf.finishRenderAndDiff()
+							completion?()
+						})
+					} else {
+						NSException.catchAndRethrow({
+							strongSelf.applyTableChanges(changes, localSections: localSections, animations: animations, completion: {
+								strongSelf.finishRenderAndDiff()
+								completion?()
+							})
+						}, failure: { exception in
+							if exception.name == NSExceptionName.internalInconsistencyException {
+								strongSelf.dumpDebugInfoForChanges(changes, previousSections: oldSections, visibleIndexPaths: visibleIndexPaths, exceptionReason: exception.reason, exceptionUserInfo: exception.userInfo)
+							}
+						})
+					}
+				}
+			}
+		}
+		
+		private func finishRenderAndDiff() {
+			renderAndDiffQueue.isSuspended = false
+		}
+		
+		internal func calculateTableChanges(oldSections: [TableSection], newSections: [TableSection], visibleIndexPaths: [IndexPath]) -> TableSectionChangeSet {
+			return TableSectionChangeSet(old: oldSections, new: newSections, visibleIndexPaths: visibleIndexPaths)
+		}
+		
+		private func applyTableChanges(_ changes: TableSectionChangeSet, localSections: [TableSection], animations: TableAnimations, completion: (() -> Void)?) {
+			guard let tableView = tableView else {
+				if let completion = completion {
+					DispatchQueue.main.async(execute: completion)
+				}
+				return
+			}
+			
+			if changes.isEmpty {
+				dataSource.data.sections = localSections
+				if let completion = completion {
+					DispatchQueue.main.async(execute: completion)
+				}
+				return
+			}
+			
+			func applyTableSectionChanges(_ changes: TableSectionChangeSet) {
+				if !changes.insertedSections.isEmpty {
+					tableView.insertSections(changes.insertedSections, with: animations.sections.insert)
+				}
+				if !changes.deletedSections.isEmpty {
+					tableView.deleteSections(changes.deletedSections, with: animations.sections.delete)
+				}
+				for movedSection in changes.movedSections {
+					tableView.moveSection(movedSection.from, toSection: movedSection.to)
+				}
+				if !changes.reloadedSections.isEmpty {
+					tableView.reloadSections(changes.reloadedSections, with: animations.sections.reload)
+				}
+				
+				if !changes.insertedRows.isEmpty {
+					tableView.insertRows(at: changes.insertedRows, with: animations.rows.insert)
+				}
+				if !changes.deletedRows.isEmpty {
+					tableView.deleteRows(at: changes.deletedRows, with: animations.rows.delete)
+				}
+				for movedRow in changes.movedRows {
+					tableView.moveRow(at: movedRow.from, to: movedRow.to)
+				}
+				if !changes.reloadedRows.isEmpty {
+					tableView.reloadRows(at: changes.reloadedRows, with: animations.rows.reload)
+				}
+			}
+			
+			func applyTransitionChanges(_ changes: TableSectionChangeSet) {
+				for update in changes.updates {
+					dataSource.cellStyler.update(cellConfig: update.cellConfig, at: update.index, in: tableView)
+				}
+			}
+			
+			CATransaction.begin()
+			CATransaction.setCompletionBlock {
+				completion?()
+			}
+			
+			tableView.beginUpdates()
+			// #4629 - There is an issue where on some occasions calling beginUpdates() will cause a heightForRowAtIndexPath() call to be made. If the sections have been changed already we may no longer find the cells
+			// in the model causing a crash. To prevent this from happening, only load the new model AFTER beginUpdates() has run
+			dataSource.data.sections = localSections
+			applyTableSectionChanges(changes)
+			tableView.endUpdates()
+			
+			// Apply transitions after we have commited section/row changes since transition indexPaths are in post-commit space
+			tableView.beginUpdates()
+			applyTransitionChanges(changes)
+			tableView.endUpdates()
+			
+			CATransaction.commit()
+		}
+		
+		private func dumpDebugInfoForChanges(_ changes: TableSectionChangeSet, previousSections: [TableSection], visibleIndexPaths: [IndexPath], exceptionReason: String?, exceptionUserInfo: [AnyHashable: Any]?) {
+			guard let exceptionHandler = FunctionalTableData.exceptionHandler else { return }
+			let exception = Exception(name: name, newSections: dataSource.data.sections, oldSections: previousSections, changes: changes, visible: visibleIndexPaths, viewFrame: tableView?.frame ?? .zero, reason: exceptionReason, userInfo: exceptionUserInfo)
+			exceptionHandler.handle(exception: exception)
+		}
+	}
+}

--- a/Sources/FunctionalTableData/TableView/FunctionalTableData+DiffableDataSource.swift
+++ b/Sources/FunctionalTableData/TableView/FunctionalTableData+DiffableDataSource.swift
@@ -1,0 +1,127 @@
+//
+//  FunctionalTableData+DiffableDataSource.swift
+//  FunctionalTableData
+//
+//  Created by Jason Kemp on 2021-03-30.
+//  Copyright © 2021 Shopify. All rights reserved.
+//
+
+import UIKit
+
+extension FunctionalTableData {
+	@available(iOS 13.0, *)
+	class DiffableDataSource: UITableViewDiffableDataSource<DiffableTableSection, AnyCellConfigType> {
+		let cellStyler: CellStyler
+		
+		var data: TableData {
+			return cellStyler.data
+		}
+		
+		init(tableView: UITableView, cellStyler: CellStyler) {
+			self.cellStyler = cellStyler
+			super.init(tableView: tableView) { (tableView, indexPath, cellConfigType) in
+				let sectionData = cellStyler.data.sections[indexPath.section]
+				let cell = cellConfigType.dequeueCell(from: tableView, at: indexPath)
+				let accessibilityIdentifier = ItemPath(sectionKey: sectionData.key, itemKey: cellConfigType.key).description
+				cellConfigType.accessibility.with(defaultIdentifier: accessibilityIdentifier).apply(to: cell)
+				cellStyler.update(cell: cell, cellConfig: cellConfigType, at: indexPath, in: tableView)
+				return cell
+			}
+		}
+		
+		override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+			guard let cellConfig = data.sections[indexPath] else { return false }
+			return cellConfig.actions.hasEditActions || self.tableView(tableView, canMoveRowAt: indexPath) || cellConfig.style?.selected != nil
+		}
+		
+		override func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
+			return data.sections[indexPath]?.actions.canBeMoved ?? false
+		}
+		
+		override func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
+			// Should only ever be moving within section
+			assert(sourceIndexPath.section == destinationIndexPath.section)
+			
+			// Update internal state to match move
+			let cell = cellStyler.data.sections[sourceIndexPath.section].rows.remove(at: sourceIndexPath.row)
+			cellStyler.data.sections[destinationIndexPath.section].rows.insert(cell, at: destinationIndexPath.row)
+			cellStyler.data.sections[sourceIndexPath.section].didMoveRow?(sourceIndexPath.row, destinationIndexPath.row)
+			super.tableView(tableView, moveRowAt: sourceIndexPath, to: destinationIndexPath)
+		}
+	}
+	
+	@available(iOS 13.0, *)
+	class DiffableDataSourceFunctionalTableDataImpl: FunctionalTableDataImpl {
+		var datasource: DiffableDataSource!
+		var isRendering: Bool = false
+		let name: String
+		let cellStyler: CellStyler
+		
+		var tableView: UITableView? {
+			didSet {
+				guard let tableView = tableView else { return }
+				let dataSource = DiffableDataSource(tableView: tableView, cellStyler: cellStyler)
+				dataSource.defaultRowAnimation = .none
+				self.datasource = dataSource
+				
+			}
+		}
+		
+		init(name: String, cellStyler: CellStyler) {
+			self.name = name
+			self.cellStyler = cellStyler
+		}
+		
+		func renderAndDiff(_ newSections: [TableSection], animated: Bool, animations: FunctionalTableData.TableAnimations, completion: (() -> Void)?) {
+			isRendering = true
+			let indexPaths = tableView?.indexPathsForVisibleRows ?? []
+			let localSections = newSections.filter { $0.rows.count > 0 }
+			tableView?.registerCellsForSections(localSections)
+			let oldSections = datasource.data.sections
+			let changeSet = TableSectionChangeSet(old: oldSections, new: localSections, visibleIndexPaths: indexPaths)
+			datasource.data.sections = localSections
+			
+			var snapshot = NSDiffableDataSourceSnapshot<DiffableTableSection, AnyCellConfigType>()
+			let diffableSections = localSections.map { DiffableTableSection($0) }
+			snapshot.appendSections(diffableSections)
+			for newSection in diffableSections {
+				snapshot.appendItems(newSection.anyRows, toSection: newSection)
+			}
+			var isFirstRender: Bool = true
+			if let snapshot = datasource?.snapshot(), snapshot.numberOfSections == 0 {
+				isFirstRender = false
+			}
+			let shouldAnimate = animated && isFirstRender
+			NSException.catchAndHandle {
+				self.datasource.apply(snapshot, animatingDifferences: shouldAnimate, completion: completion)
+			} failure: { (exception) in
+				NSException.catchAndRethrow {
+					self.datasource.apply(snapshot, animatingDifferences: false, completion: completion)
+				} failure: { (exception) in
+					if exception.name == NSExceptionName.internalInconsistencyException {
+						
+						dumpDebugInfoForChanges(changeSet,
+												previousSections: oldSections,
+												visibleIndexPaths: indexPaths,
+												exceptionReason: exception.reason,
+												exceptionUserInfo: exception.userInfo)
+					}
+				}
+			}
+			isRendering = false
+		}
+		
+		private func dumpDebugInfoForChanges(_ changes: TableSectionChangeSet, previousSections: [TableSection], visibleIndexPaths: [IndexPath], exceptionReason: String?, exceptionUserInfo: [AnyHashable: Any]?) {
+			guard let exceptionHandler = FunctionalTableData.exceptionHandler else { return }
+			let exception = Exception(name: name,
+									  newSections: cellStyler.data.sections,
+									  oldSections: previousSections,
+									  changes: changes,
+									  visible: visibleIndexPaths,
+									  viewFrame: tableView?.frame ?? .zero,
+									  reason: exceptionReason,
+									  userInfo: exceptionUserInfo)
+			exceptionHandler.handle(exception: exception)
+		}
+	}
+}

--- a/Sources/FunctionalTableData/TableView/FunctionalTableData+UITableViewDataSource.swift
+++ b/Sources/FunctionalTableData/TableView/FunctionalTableData+UITableViewDataSource.swift
@@ -10,8 +10,8 @@ import UIKit
 
 extension FunctionalTableData {
 	class DataSource: NSObject, UITableViewDataSource {
-		private let data: TableData
-		private var cellStyler: CellStyler
+		let data: TableData
+		private(set) var cellStyler: CellStyler
 		
 		init(cellStyler: CellStyler) {
 			self.cellStyler = cellStyler
@@ -56,5 +56,5 @@ extension FunctionalTableData {
 			guard let cellConfig = data.sections[indexPath] else { return false }
 			return cellConfig.actions.hasEditActions || self.tableView(tableView, canMoveRowAt: indexPath) || cellConfig.style?.selected != nil
 		}
-	}
+	}	
 }

--- a/Sources/FunctionalTableData/TableView/TableItemConfigType.swift
+++ b/Sources/FunctionalTableData/TableView/TableItemConfigType.swift
@@ -12,9 +12,3 @@ public protocol TableItemConfigType {
 	func register(with tableView: UITableView)
 	func dequeueCell(from tableView: UITableView, at indexPath: IndexPath) -> UITableViewCell
 }
-
-extension TableItemConfigType {
-	public func dequeueCell(from tableView: UITableView, at indexPath: IndexPath) -> UITableViewCell {
-		return tableView.dequeueReusableCell(withIdentifier: UITableViewCell.reuseIdentifier, for: indexPath)
-	}
-}

--- a/Tests/FunctionalTableDataTests/DiffableDataSourceFunctionalDataTests.swift
+++ b/Tests/FunctionalTableDataTests/DiffableDataSourceFunctionalDataTests.swift
@@ -1,0 +1,92 @@
+//
+//  DiffableDataSourceFunctionalDataTests.swift
+//  FunctionalTableDataTests
+//
+//  Created by Jason Kemp on 2021-03-17.
+//
+
+import XCTest
+@testable import FunctionalTableData
+
+class DiffableDataSourceFunctionalDataTests: XCTestCase {
+	func testKeyPathFromRowKey() {
+		let tableData = FunctionalTableData(name: nil, diffingStrategy: .diffableDataSource)
+		let tableView = UITableView()
+		
+		tableData.tableView = tableView
+		
+		let expectation1 = expectation(description: "first append")
+		let cellConfigC1 = TestCaseCell(key: "color1", state: TestCaseState(data: "red"), cellUpdater: TestCaseState.updateView)
+		let cellConfigC2 = TestCaseCell(key: "red2", state: TestCaseState(data: "green"), cellUpdater: TestCaseState.updateView)
+		let sectionC1 = TableSection(key: "colors Section", rows: [cellConfigC1, cellConfigC2])
+		
+		let cellConfigS1 = TestCaseCell(key: "size1", state: TestCaseState(data: "medium"), cellUpdater: TestCaseState.updateView)
+		let cellConfigS2 = TestCaseCell(key: "size2", state: TestCaseState(data: "large"), cellUpdater: TestCaseState.updateView)
+		let sectionS1 = TableSection(key: "sizes Section", rows: [cellConfigS1, cellConfigS2])
+		
+		tableData.renderAndDiff([sectionC1, sectionS1]) { [weak tableData] in
+			expectation1.fulfill()
+			
+			if let tableData = tableData, let keyPath = tableData.keyPathForRowKey("size1") {
+				XCTAssertTrue(keyPath.sectionKey == "sizes Section" && keyPath.rowKey == "size1")
+			} else {
+				XCTFail()
+			}
+		}
+		
+		waitForExpectations(timeout: 1, handler: nil)
+	}
+	
+	func testRetrievingIndexPathFromInvalidKeyPath() {
+		let tableData = FunctionalTableData(name: nil, diffingStrategy: .diffableDataSource)
+		let tableView = UITableView()
+		
+		tableData.tableView = tableView
+		let expectation1 = expectation(description: "first append")
+		let cellConfigC1 = TestCaseCell(key: "red1", state: TestCaseState(data: "red"), cellUpdater: TestCaseState.updateView)
+		let sectionC1 = TableSection(key: "colors Section", rows: [cellConfigC1])
+		tableData.renderAndDiff([sectionC1]) {
+			expectation1.fulfill()
+		}
+		waitForExpectations(timeout: 1, handler: nil)
+		
+		XCTAssertNil(tableData.indexPathFromKeyPath(FunctionalTableData.KeyPath(sectionKey: "Invalid Section", rowKey: "red1")))
+		XCTAssertNil(tableData.indexPathFromKeyPath(FunctionalTableData.KeyPath(sectionKey: "colors Section", rowKey: "Invalid Row")))
+	}
+	
+	func testRetrievingIndexPathFromValidKeyPath() {
+		let tableData = FunctionalTableData(name: nil, diffingStrategy: .diffableDataSource)
+		let tableView = UITableView()
+		
+		tableData.tableView = tableView
+		let expectation1 = expectation(description: "first append")
+		let cellConfigC1 = TestCaseCell(key: "red1", state: TestCaseState(data: "red"), cellUpdater: TestCaseState.updateView)
+		let sectionC1 = TableSection(key: "colors Section", rows: [cellConfigC1])
+		
+		tableData.renderAndDiff([sectionC1]) {
+			expectation1.fulfill()
+		}
+		waitForExpectations(timeout: 1, handler: nil)
+		
+		let indexPath = tableData.indexPathFromKeyPath(FunctionalTableData.KeyPath(sectionKey: "colors Section", rowKey: "red1"))
+		XCTAssertNotNil(indexPath)
+	}
+	
+	func testCellAccessibilityIdentifiers() {
+		let tableData = FunctionalTableData(name: nil, diffingStrategy: .diffableDataSource)
+		let tableView = UITableView()
+		
+		tableData.tableView = tableView
+		let expectation1 = expectation(description: "rendered")
+		let cellConfig = TestCaseCell(key: "cellKey", state: TestCaseState(data: "red"), cellUpdater: TestCaseState.updateView)
+		let section = TableSection(key: "sectionKey", rows: [cellConfig])
+		
+		tableData.renderAndDiff([section]) {
+			expectation1.fulfill()
+		}
+		waitForExpectations(timeout: 1, handler: nil)
+		
+		let cell = tableData.tableView?.visibleCells.first
+		XCTAssertEqual(cell?.accessibilityIdentifier, "sectionKey.cellKey")
+	}
+}

--- a/Tests/FunctionalTableDataTests/DiffableDataSourceFunctionalTableDataPerformanceTests.swift
+++ b/Tests/FunctionalTableDataTests/DiffableDataSourceFunctionalTableDataPerformanceTests.swift
@@ -1,0 +1,79 @@
+//
+//  DiffableDataSourceFunctionalTableDataPerformanceTests.swift
+//  
+//
+//  Created by Jason Kemp on 2021-03-17.
+//
+
+import XCTest
+@testable import FunctionalTableData
+
+class DiffableDataSourceFunctionaltableDataPerformanceTests: XCTestCase {
+	private let functionalData = FunctionalTableData(name: nil, diffingStrategy: .diffableDataSource)
+	
+	func testPerformanceByMovingRows() {
+		let totalSections = 5
+		let totalRows = 200
+		
+		let oldSections =  mockSections(sectionsCount: totalSections, rowsCount: totalRows) { index -> String in
+			return "row-\(index)"
+		}
+
+		let newSections: [TableSection] = mockSections(sectionsCount: totalSections, rowsCount: totalRows) { index -> String in
+			return "row-\((totalRows - 1) - index)"
+		}
+
+		measure {
+			_ = functionalData.calculateTableChanges(oldSections: oldSections, newSections: newSections, visibleIndexPaths: [])
+		}
+	}
+	
+	func testPerformanceByAddingRows() {
+		let newSections: [TableSection] = mockSections(sectionsCount: 10, rowsCount: 10_000) { index -> String in
+			return "row-\(index)"
+		}
+		
+		measure {
+			_ = functionalData.calculateTableChanges(oldSections: [], newSections: newSections, visibleIndexPaths: [])
+		}
+	}
+	
+	func testPerformanceByDeletingRows() {
+		let oldSections: [TableSection] = mockSections(sectionsCount: 10, rowsCount: 10_000) { index -> String in
+			return "row-\(index)"
+		}
+		
+		measure {
+			_ = functionalData.calculateTableChanges(oldSections: oldSections, newSections: [], visibleIndexPaths: [])
+		}
+	}
+	
+	func testPerformanceByKeepingRows() {
+		let oldSections: [TableSection] = mockSections(sectionsCount: 10, rowsCount: 10_000) { index -> String in
+			return "row-\(index)"
+		}
+		
+		let newSections = oldSections
+		
+		measure {
+			_ = functionalData.calculateTableChanges(oldSections: oldSections, newSections: newSections, visibleIndexPaths: [])
+		}
+	}
+
+	private func mockSections(sectionsCount: Int, rowsCount: Int, keyBuilder: (Int) -> String) -> [TableSection] {
+		var sections: [TableSection] = []
+		for i in 0..<sectionsCount {
+			sections.append(
+				TableSection(
+					key: "section\(i)",
+					rows: (0..<rowsCount).map {
+						TestCaseCell(key: keyBuilder($0), state: TestCaseState(data: "data-\(i)"), cellUpdater: TestCaseState.updateView)
+					}
+				)
+			)
+		}
+		
+		return sections
+	}
+}
+

--- a/Tests/FunctionalTableDataTests/DiffableDataSourceTableCellReuseTests.swift
+++ b/Tests/FunctionalTableDataTests/DiffableDataSourceTableCellReuseTests.swift
@@ -1,0 +1,87 @@
+//
+//  DiffableDataSourceTableCellReuseTests.swift
+//  
+//
+//  Created by Jason Kemp on 2021-03-17.
+//
+
+import XCTest
+import Foundation
+@testable import FunctionalTableData
+
+class DiffableDataSourceTableCellReuseTests: XCTestCase {
+	private typealias LabelCell = HostCell<UILabel, String, LayoutMarginsTableItemLayout>
+	
+	private var tableView: UITableView!
+	private var tableModel: FunctionalTableData!
+	
+	override func setUp() {
+		super.setUp()
+		tableView = UITableView()
+		tableModel = FunctionalTableData()
+		tableModel.tableView = tableView
+	}
+	
+	override func tearDown() {
+		tableView = nil
+		tableModel = nil
+		super.tearDown()
+	}
+	
+	// q.v. https://github.com/Shopify/FunctionalTableData/pull/97
+	// Test that cells do not inherit leftover styles from a previous cell config
+	func testCellStyleClearedOnReuse() throws {
+		let disclosureCell = mockCell(key: "cell", style: CellStyle(highlight: true, accessoryType: .disclosureIndicator))
+		let unstyledCell = mockCell(key: "cell", style: nil)
+		
+		var originalCellView: UITableViewCell?
+		
+		let renderedDisclosureCell = expectation(description: "Finished rendering disclosure cell")
+		tableModel.renderAndDiff([TableSection(key: "section", rows: [disclosureCell])], animated: false) {
+			defer {
+				renderedDisclosureCell.fulfill()
+			}
+			
+			guard let cellView = self.tableView.visibleCells.first else {
+				XCTFail("Tableview has no cell views")
+				return
+			}
+			
+			XCTAssertEqual(cellView.accessoryType, .disclosureIndicator)
+			XCTAssertEqual(cellView.selectionStyle, .default)
+			
+			// Keep a reference to check that the same cell view is reused for the new state
+			originalCellView = cellView
+		}
+		
+		wait(for: [renderedDisclosureCell], timeout: 10.0)
+		
+		let renderedUnstyledCell = expectation(description: "Finished rendering unstyled cell")
+		tableModel.renderAndDiff([TableSection(key: "section", rows: [unstyledCell])], animated: false) {
+			defer {
+				renderedUnstyledCell.fulfill()
+			}
+			
+			guard let cellView = self.tableView.visibleCells.first else {
+				XCTFail("Tableview has no cell views")
+				return
+			}
+			
+			XCTAssertEqual(cellView, originalCellView, "Original cell view was not reused")
+			
+			XCTAssertEqual(cellView.accessoryType, .none)
+			XCTAssertEqual(cellView.selectionStyle, .none)
+		}
+		
+		wait(for: [renderedUnstyledCell], timeout: 10.0)
+	}
+	
+	private func mockCell(key: String, style: CellStyle?) -> CellConfigType {
+		return LabelCell(
+			key: key,
+			style: style,
+			state: "",
+			cellUpdater: { _, _ in })
+	}
+}
+

--- a/Tests/FunctionalTableDataTests/TableSectionChangeSetTests.swift
+++ b/Tests/FunctionalTableDataTests/TableSectionChangeSetTests.swift
@@ -610,6 +610,10 @@ fileprivate struct TestHeaderFooter: TableHeaderFooterConfigType {
 	func register(with tableView: UITableView) {
 		tableView.registerReusableHeaderFooterView(HeaderFooter.self)
 	}
+	
+	func dequeueCell(from tableView: UITableView, at indexPath: IndexPath) -> UITableViewCell {
+		UITableViewCell()
+	}
 
 	func dequeueHeaderFooter(from tableView: UITableView) -> UITableViewHeaderFooterView? {
 		return tableView.dequeueReusableHeaderFooterView(HeaderFooter.self)

--- a/Tests/FunctionalTableDataTests/TableSectionTests.swift
+++ b/Tests/FunctionalTableDataTests/TableSectionTests.swift
@@ -133,6 +133,10 @@ fileprivate struct TestHeaderFooter: TableHeaderFooterConfigType {
 	func register(with tableView: UITableView) {
 		tableView.registerReusableHeaderFooterView(HeaderFooter.self)
 	}
+	
+	func dequeueCell(from tableView: UITableView, at indexPath: IndexPath) -> UITableViewCell {
+		UITableViewCell()
+	}
 
 	func dequeueHeaderFooter(from tableView: UITableView) -> UITableViewHeaderFooterView? {
 		return tableView.dequeueReusableHeaderFooterView(HeaderFooter.self)


### PR DESCRIPTION
To workaround crashes in UITableView with large change sets, use UITableViewDiffableDataSource when available (iOS 13 or greater)

Created an Impl protocol, with two implementations:

1. Original Functional Table Data algorithm
2. UITableViewDiffableDataSource-backed implementation for iOS 13 and up.

Then just followed the consequences of that. Any other changes are due to getting it working on IOS 13 at runtime. Tests with data exhibiting the crash with the original table data algorithm pass with diffable data sources.