### PR TITLE
Fix boolean logic to not animate on first load of data

### DIFF
--- a/Sources/FunctionalTableData/TableView/FunctionalTableData+DiffableDataSource.swift
+++ b/Sources/FunctionalTableData/TableView/FunctionalTableData+DiffableDataSource.swift
@@ -91,7 +91,7 @@ extension FunctionalTableData {
 			if let snapshot = datasource?.snapshot(), snapshot.numberOfSections == 0 {
 				isFirstRender = false
 			}
-			let shouldAnimate = animated && isFirstRender
+			let shouldAnimate = animated && !isFirstRender
 			NSException.catchAndHandle {
 				self.datasource.apply(snapshot, animatingDifferences: shouldAnimate, completion: completion)
 			} failure: { (exception) in


### PR DESCRIPTION
Fixes little bug introduced in the last commit.

Boolean value was incorrect, so it would animate on the first pass; we want the opposite.