### PR TITLE
Selection fix

### DIFF
--- a/Sources/FunctionalTableData/TableView/FunctionalTableData+UITableViewDelegate.swift
+++ b/Sources/FunctionalTableData/TableView/FunctionalTableData+UITableViewDelegate.swift
@@ -86,8 +86,8 @@ extension FunctionalTableData {
 		
 		public func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
             
-            //This fixes bug when selecting cells quickly in list view; without this could sometimes get behaviour where tableview cell was selected on the screen, but cell state selection status was not update. This may be due to the fact that state status is updated when cellConfig?.actions.selectionAction function is called. This function is only called in didSelectRowAt function, and could potentially not always fire.
-            guard tableView.cellForRow(at: indexPath) != nil else { return nil }
+        	// This fixes a bug when selecting cells quickly in a table view; without this, a tableview cell can be selected on the screen, but the cell state selection status is not updated. This may be due to the fact that state status is updated when cellConfig?.actions.selectionAction function is called. This function is only called in didSelectRowAt function, and could potentially not always fire.
+        	guard tableView.cellForRow(at: indexPath) != nil else { return nil }
             
 			if tableView.indexPathForSelectedRow == indexPath {
 				return nil

--- a/Tests/FunctionalTableDataTests/DiffableDataSourceFunctionalDataTests.swift
+++ b/Tests/FunctionalTableDataTests/DiffableDataSourceFunctionalDataTests.swift
@@ -74,9 +74,7 @@ class DiffableDataSourceFunctionalDataTests: XCTestCase {
 	
 	func testCellAccessibilityIdentifiers() {
 		let tableData = FunctionalTableData(name: nil, diffingStrategy: .diffableDataSource)
-		let tableView = UITableView()
-		
-		tableData.tableView = tableView
+		tableData.tableView = WindowWithTableViewMounted().tableView
 		let expectation1 = expectation(description: "rendered")
 		let cellConfig = TestCaseCell(key: "cellKey", state: TestCaseState(data: "red"), cellUpdater: TestCaseState.updateView)
 		let section = TableSection(key: "sectionKey", rows: [cellConfig])

--- a/Tests/FunctionalTableDataTests/DiffableDataSourceTableCellReuseTests.swift
+++ b/Tests/FunctionalTableDataTests/DiffableDataSourceTableCellReuseTests.swift
@@ -12,19 +12,19 @@ import Foundation
 class DiffableDataSourceTableCellReuseTests: XCTestCase {
 	private typealias LabelCell = HostCell<UILabel, String, LayoutMarginsTableItemLayout>
 	
-	private var tableView: UITableView!
+	private var window: WindowWithTableViewMounted!
 	private var tableModel: FunctionalTableData!
 	
 	override func setUp() {
 		super.setUp()
-		tableView = UITableView()
+		window = WindowWithTableViewMounted()
 		tableModel = FunctionalTableData()
-		tableModel.tableView = tableView
+		tableModel.tableView = window.tableView
 	}
 	
 	override func tearDown() {
-		tableView = nil
 		tableModel = nil
+		window.tearDownWindow()
 		super.tearDown()
 	}
 	
@@ -42,7 +42,7 @@ class DiffableDataSourceTableCellReuseTests: XCTestCase {
 				renderedDisclosureCell.fulfill()
 			}
 			
-			guard let cellView = self.tableView.visibleCells.first else {
+			guard let cellView = self.window.tableView.visibleCells.first else {
 				XCTFail("Tableview has no cell views")
 				return
 			}
@@ -62,7 +62,7 @@ class DiffableDataSourceTableCellReuseTests: XCTestCase {
 				renderedUnstyledCell.fulfill()
 			}
 			
-			guard let cellView = self.tableView.visibleCells.first else {
+			guard let cellView = self.window.tableView.visibleCells.first else {
 				XCTFail("Tableview has no cell views")
 				return
 			}

--- a/Tests/FunctionalTableDataTests/FunctionalDataTests.swift
+++ b/Tests/FunctionalTableDataTests/FunctionalDataTests.swift
@@ -75,7 +75,7 @@ class FunctionalDataTests: XCTestCase {
 	
 	func testCellAccessibilityIdentifiers() {
 		let tableData = FunctionalTableData()
-		let tableView = UITableView()
+		let tableView = WindowWithTableViewMounted().tableView
 		
 		tableData.tableView = tableView
 		let expectation1 = expectation(description: "rendered")

--- a/Tests/FunctionalTableDataTests/Helpers/WindowWithTableViewMounted.swift
+++ b/Tests/FunctionalTableDataTests/Helpers/WindowWithTableViewMounted.swift
@@ -1,0 +1,63 @@
+import UIKit
+
+
+
+final class WindowWithTableViewMounted {
+    
+	private var rootWindow: UIWindow!
+	let tableView = UITableView()
+	private let tableViewController : TableViewControllerWithTableViewMounted
+
+	init() {
+		self.tableViewController = TableViewControllerWithTableViewMounted(tableView)
+		setUpWindowWithTableView()
+		presentWindow()
+	}
+
+	private func setUpWindowWithTableView() {
+		rootWindow = UIWindow(frame: UIScreen.main.bounds)
+		rootWindow.rootViewController = tableViewController
+	}
+
+	private func presentWindow() {
+		rootWindow.isHidden = false
+		tableViewController.viewWillAppear(false)
+		tableViewController.viewDidAppear(false)
+	}
+
+	func tearDownWindow() {
+		tableViewController.viewWillDisappear(false)
+		tableViewController.viewDidDisappear(false)
+		rootWindow.rootViewController = nil
+		rootWindow.isHidden = true
+		self.rootWindow = nil
+	}
+}
+
+
+private final class TableViewControllerWithTableViewMounted: UIViewController {
+	let tableView : UITableView
+    
+	init(_ tableView: UITableView) {
+		self.tableView = tableView
+		super.init(nibName: nil, bundle: nil)
+	}
+    
+	required init?(coder: NSCoder) {
+		fatalError("init(coder:) has not been implemented")
+	}
+    
+	override func loadView() {
+		super.loadView()
+		setupTableView()
+	}
+    
+	func setupTableView() {
+		view.addSubview(tableView)
+		tableView.translatesAutoresizingMaskIntoConstraints = false
+		tableView.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
+		tableView.leftAnchor.constraint(equalTo: view.leftAnchor).isActive = true
+		tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
+		tableView.rightAnchor.constraint(equalTo: view.rightAnchor).isActive = true
+	}
+}

--- a/Tests/FunctionalTableDataTests/TableCellReuseTests.swift
+++ b/Tests/FunctionalTableDataTests/TableCellReuseTests.swift
@@ -13,18 +13,18 @@ import Foundation
 class TableCellReuseTests: XCTestCase {
 	private typealias LabelCell = HostCell<UILabel, String, LayoutMarginsTableItemLayout>
 	
-	private var tableView: UITableView!
+	private var window: WindowWithTableViewMounted!
 	private var tableModel: FunctionalTableData!
 	
 	override func setUp() {
 		super.setUp()
-		tableView = UITableView()
+		window = WindowWithTableViewMounted()
 		tableModel = FunctionalTableData()
-		tableModel.tableView = tableView
+		tableModel.tableView = window.tableView
 	}
 	
 	override func tearDown() {
-		tableView = nil
+		window.tearDownWindow()
 		tableModel = nil
 		super.tearDown()
 	}
@@ -43,7 +43,7 @@ class TableCellReuseTests: XCTestCase {
 				renderedDisclosureCell.fulfill()
 			}
 			
-			guard let cellView = self.tableView.visibleCells.first else {
+			guard let cellView = self.window.tableView.visibleCells.first else {
 				XCTFail("Tableview has no cell views")
 				return
 			}
@@ -63,7 +63,7 @@ class TableCellReuseTests: XCTestCase {
 				renderedUnstyledCell.fulfill()
 			}
 			
-			guard let cellView = self.tableView.visibleCells.first else {
+			guard let cellView = self.window.tableView.visibleCells.first else {
 				XCTFail("Tableview has no cell views")
 				return
 			}


### PR DESCRIPTION
### The Problem

Multi selection list view had a bug whereby some cells could be selected despite the maximum allowed number of selected cells being reached. See video:

https://user-images.githubusercontent.com/103146151/168328554-1c1c3078-dc60-4064-8e46-936d74fcd791.mov

### Why Was this Happening?

The problem was within the FunctionalTableData package. It seems that some cells were being selected with native UIKit functionality, but these selections were never updating the FunctionalTableData state as the cell was null in the call to this function.

### The Solution

A cell null check was placed at the top of willSelectRowAt method. If null cells are checked here and, if so, the function is returned at the top of the method, no native UIKit selection takes place.

https://user-images.githubusercontent.com/103146151/168328603-c837b931-0910-4618-8513-8c3a76921b77.mov

### Other Secondary Changes

Because FunctionalTableData was written years ago, certain tests were failing on iOS 15. These tests had to do with calling visible cells. The visible cells method on UITable used to return cells in iOS 14, even in unmounted tables (which is what was being used). However, this function now returns nil in iOS 15. The fix was to create a UITable that is mounted to a UIWindow for testing.