### PR TITLE
Switch `height` to a function and not a variable

### DIFF
--- a/Sources/FunctionalTableData/TableSectionHeaderFooter.swift
+++ b/Sources/FunctionalTableData/TableSectionHeaderFooter.swift
@@ -17,6 +17,13 @@ public protocol TableHeaderFooterConfigType: TableItemConfigType {
 	func dequeueHeaderFooter(from tableView: UITableView) -> UITableViewHeaderFooterView?
 	func isEqual(_ other: TableHeaderFooterConfigType?) -> Bool
 	var height: CGFloat { get }
+	func height(given width: CGFloat) -> CGFloat?
+}
+
+extension TableHeaderFooterConfigType {
+	public func height(given width: CGFloat) -> CGFloat? {
+		nil
+	}
 }
 
 public protocol TableHeaderFooterStateType: Equatable {
@@ -24,6 +31,14 @@ public protocol TableHeaderFooterStateType: Equatable {
 	var height: CGFloat { get }
 	var topSeparatorHidden: Bool { get }
 	var bottomSeparatorHidden: Bool { get }
+	
+	func height(given width: CGFloat) -> CGFloat?
+}
+
+extension TableHeaderFooterStateType {
+	public func height(given width: CGFloat) -> CGFloat? {
+		nil
+	}
 }
 
 public struct TableSectionHeaderFooter<ViewType: UIView, Layout: TableItemLayout, S: TableHeaderFooterStateType>: TableHeaderFooterConfigType {
@@ -53,7 +68,11 @@ public struct TableSectionHeaderFooter<ViewType: UIView, Layout: TableItemLayout
 	}
 	
 	public var height: CGFloat {
-		return state?.height ?? 0
+		state?.height ?? 0
+	}
+	
+	public func height(given width: CGFloat) -> CGFloat? {
+		return state?.height(given: width) ?? height
 	}
 
 	// MARK: - TableHeaderFooterConfigType

--- a/Sources/FunctionalTableData/TableView/FunctionalTableData+UITableViewDelegate.swift
+++ b/Sources/FunctionalTableData/TableView/FunctionalTableData+UITableViewDelegate.swift
@@ -49,7 +49,7 @@ extension FunctionalTableData {
 				// When given a height of zero grouped style UITableView's use their default value instead of zero. By returning CGFloat.min we get around this behavior and force UITableView to end up using a height of zero after all.
 				return tableView.style == .grouped ? CGFloat.leastNormalMagnitude : 0
 			}
-			return header.height
+			return header.height(given: tableView.frame.width) ?? header.height
 		}
 		
 		public func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
@@ -57,7 +57,7 @@ extension FunctionalTableData {
 				// When given a height of zero grouped style UITableView's use their default value instead of zero. By returning CGFloat.min we get around this behavior and force UITableView to end up using a height of zero after all.
 				return tableView.style == .grouped ? CGFloat.leastNormalMagnitude : 0
 			}
-			return footer.height
+			return footer.height(given: tableView.frame.width) ?? footer.height
 		}
 		
 		public func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {

--- a/Tests/FunctionalTableDataTests/CollectionSectionChangeSetTests.swift
+++ b/Tests/FunctionalTableDataTests/CollectionSectionChangeSetTests.swift
@@ -654,7 +654,7 @@ fileprivate struct TestHeaderFooter: TableHeaderFooterConfigType, CollectionSupp
 		guard let other = other as? TestHeaderFooter else { return false }
 		return state == other.state
 	}
-
+	
 	var height: CGFloat {
 		return state?.height ?? 0
 	}


### PR DESCRIPTION
These changes allow for header and footer width to be passed to the functional table data.
More specifically, `FunctionalTableData.Delegate`'s `UITableViewDelegate` implemenation now
uses `tableView`'s width in `tableView(_:heightForHeaderInSection:)` and `tableView(_:heightForFooterInSection)`.

We achieved this functionality while maintaining backwards compatibility by adding a
protocol method to both `TableHeaderFooterConfigType` and `TableHeaderFooterStateType` called
`func height(given width: CGFloat) -> CGFloat?`.  If this method returns `nil`, then
the table view delegate methods will use the current `height` property already defined, otherwise
it will use the provided by the new methods.

Each protocol provides a public default implemenation so that library consumers
need not implement this method unnecessarily.
